### PR TITLE
Load layer datasets directly from disk instead of fetching from the API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,3 @@
 *.csv
 *.pyc
 *.xlsx
-assets/datasets/crime.geojson
-assets/datasets/oil_well.geojson

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ __pycache__/larentals.cpython-310.pyc
 *.csv
 *.pyc
 *.xlsx
-assets/datasets/crime.geojson
 env
 hdf
 larentals-checkpoint.py

--- a/functions/layers.py
+++ b/functions/layers.py
@@ -1,13 +1,8 @@
 from dash_extensions.javascript import Namespace
-from datetime import datetime, timedelta
 from dotenv import load_dotenv
-from functions.geojson_processing_utils import fetch_json_data, convert_to_geojson
-from sodapy import Socrata
 from typing import Any, ClassVar, Optional
-from urllib.parse import urlparse
 import dash_leaflet as dl
 import json
-import os
 import uuid
 
 load_dotenv()


### PR DESCRIPTION
I'd like to split API data fetching into its own separate thing (maybe a database server?) instead of using the Dash app to do that. 
The crime and oil well GeoJSONs now live on the disk and are loaded via `dl.GeoJSON`'s `url` parameter.

I haven't come up with a function to generate fresh data, but I think I can just do that every week when the new lease/buy datasets come out. The oil well and crime data isn't really critical imo so it's OK if it's a little outdated.