### PR TITLE
Datepicker improvements

### DIFF
--- a/assets/javascript/clientside_callbacks.js
+++ b/assets/javascript/clientside_callbacks.js
@@ -36,6 +36,24 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
             }
         },
 
+        updateDatePicker: function(selectedDays, earliestDate) {
+            var today = new Date();
+            function formatDate(d) {
+                var year = d.getFullYear();
+                var month = (d.getMonth() + 1).toString().padStart(2, '0');
+                var day = d.getDate().toString().padStart(2, '0');
+                return year + '-' + month + '-' + day;
+            }
+            if (selectedDays > 0) {
+                var startDate = new Date();
+                startDate.setDate(today.getDate() - parseInt(selectedDays));
+                return formatDate(startDate);
+            } else {
+                // Return the stored earliest date
+                return earliestDate;
+            }
+        },
+
         /**
          * Filters GeoJSON features according to user-selected criteria.
          *

--- a/pages/buy_page.py
+++ b/pages/buy_page.py
@@ -36,9 +36,13 @@ geojson_store = dcc.Store(id='buy-geojson-store', storage_type='memory', data=co
 #logger.debug(f"GeoJSON data: {geojson_store.data}")
 #logger.debug(f"this is the return geojson {lease_components.return_geojson()}")
 
+# Create a Store to hold the earliest listed date
+earliest_date_store = dcc.Store(id="earliest_date_store", data=components.earliest_date) 
+
 layout = dbc.Container([
   collapse_store,
   geojson_store,
+  earliest_date_store,
   dbc.Row( # First row: title card
     [
       dbc.Col([components.title_card, components.user_options_card], lg=3, md=6, sm=4),
@@ -129,8 +133,8 @@ clientside_callback(
     Input('yrbuilt_missing_radio', 'value'),
     Input('senior_community_radio', 'value'),
     Input('subtype_checklist', 'value'),
-    Input('listed_date_datepicker', 'start_date'),
-    Input('listed_date_datepicker', 'end_date'),
+    Input('listed_date_datepicker_buy', 'start_date'),
+    Input('listed_date_datepicker_buy', 'end_date'),
     Input('listed_date_missing_radio', 'value'),
     Input('hoa_fee_slider', 'value'),
     Input('hoa_fee_missing_radio', 'value'),
@@ -152,4 +156,14 @@ clientside_callback(
     Output({'type': 'dynamic_toggle_button_buy', 'index': MATCH}, 'children')
   ],
   [Input({'type': 'dynamic_toggle_button_buy', 'index': MATCH}, 'n_clicks')]
+)
+
+clientside_callback(
+  ClientsideFunction(
+    namespace='clientside',
+    function_name='updateDatePicker'
+  ),
+  Output('listed_date_datepicker_buy', 'start_date'),
+  Input('listed_time_range_radio', 'value'),
+  State('earliest_date_store', 'data'),
 )

--- a/pages/components.py
+++ b/pages/components.py
@@ -1704,7 +1704,8 @@ class BuyComponents(BaseClass):
                     id='listed_date_datepicker',
                     max_date_allowed=today,
                     start_date=self.earliest_date,
-                    end_date=today
+                    end_date=today,
+                    initial_visible_month=today,
                 ),
                 # Alert about missing listed dates
                 dbc.Alert(

--- a/pages/components.py
+++ b/pages/components.py
@@ -1680,18 +1680,12 @@ class BuyComponents(BaseClass):
                 html.H5("Listed Date Range", style={'display': 'inline-block', 'marginRight': '10px'}),
                 create_toggle_button(index='listed_date', initial_label="Hide", page_type='buy')
             ]),
-            # Main content for listed date
+            # Main content for listed date: radio buttons then DatePicker and alert
             html.Div([
-                # DatePicker component
-                dcc.DatePickerRange(
-                    id='listed_date_datepicker',
-                    max_date_allowed=today,
-                    start_date=self.earliest_date,
-                    end_date=today
-                ),
-                # Header and radio buttons for time range directly underneath
+                # Radio buttons placed before the date picker
                 html.Div([
-                    html.H6(html.Em("I want to see listings posted in the last..."), style={'marginBottom': '5px'}),
+                    html.H6(html.Em("I want to see listings posted in the last..."), 
+                            style={'marginBottom': '5px'}),
                     dcc.RadioItems(
                         id='listed_time_range_radio',
                         options=[
@@ -1704,7 +1698,14 @@ class BuyComponents(BaseClass):
                         inline=True,
                         labelStyle={'fontSize': '0.8rem', 'marginRight': '10px'}
                     )
-                ], style={'marginTop': '5px'}),
+                ], style={'marginBottom': '5px'}),
+                # DatePicker component
+                dcc.DatePickerRange(
+                    id='listed_date_datepicker',
+                    max_date_allowed=today,
+                    start_date=self.earliest_date,
+                    end_date=today
+                ),
                 # Alert about missing listed dates
                 dbc.Alert(
                     [
@@ -1725,10 +1726,7 @@ class BuyComponents(BaseClass):
                     style={'marginTop': '5px'}
                 ),
             ], id={'type': 'dynamic_output_div_buy', 'index': 'listed_date'})
-        ],
-        style={'marginBottom': '10px'},
-        id='listed_date_div_buy'
-        )
+        ], style={'marginBottom': '10px'}, id='listed_date_div_buy')
         
         return listed_date_components
 

--- a/pages/components.py
+++ b/pages/components.py
@@ -113,6 +113,7 @@ class LeaseComponents(BaseClass):
 
         self.bathrooms_slider = self.create_bathrooms_slider()
         self.bedrooms_slider = self.create_bedrooms_slider()
+        self.earliest_date = (self.df['listed_date'].min()).to_pydatetime()
         self.furnished_checklist = self.create_furnished_checklist()
         self.garage_spaces_components = self.create_garage_spaces_components()
         self.key_deposit_components = self.create_key_deposit_components()
@@ -936,22 +937,41 @@ class LeaseComponents(BaseClass):
     def create_listed_date_components(self):
         # Get today's date and set it as the end date for the date picker
         today = date.today()
-        # Get the earliest date and convert it to Pythonic datetime for Dash
-        self.df['listed_date'] = pd.to_datetime(self.df['listed_date'], errors='coerce')
-        earliest_date = (self.df['listed_date'].min()).to_pydatetime()
         
         listed_date_components = html.Div([
+            # Top header: Listed Date Range with toggle button
             html.Div([
                 html.H5("Listed Date Range", style={'display': 'inline-block', 'marginRight': '10px'}),
                 create_toggle_button(index='listed_date', initial_label="Hide", page_type='lease')
             ]),
+            # Main content for listed date: radio buttons then DatePicker and alert
             html.Div([
+                # Radio buttons placed before the date picker
+                html.Div([
+                    html.H6(html.Em("I want to see listings posted in the last..."), 
+                            style={'marginBottom': '5px'}),
+                    dcc.RadioItems(
+                        id='listed_time_range_radio',
+                        options=[
+                            {'label': '2 Weeks', 'value': 14},
+                            {'label': '1 Month', 'value': 30},
+                            {'label': '3 Months', 'value': 90},
+                            {'label': 'All Time', 'value': 0}
+                        ],
+                        value=0,
+                        inline=True,
+                        labelStyle={'fontSize': '0.8rem', 'marginRight': '10px'}
+                    )
+                ], style={'marginBottom': '5px'}),
+                # DatePicker component
                 dcc.DatePickerRange(
-                    id='listed_date_datepicker',
+                    id='listed_date_datepicker_lease',
                     max_date_allowed=today,
-                    start_date=earliest_date,
-                    end_date=today
+                    start_date=self.earliest_date,
+                    end_date=today,
+                    initial_visible_month=today,
                 ),
+                # Alert about missing listed dates
                 dbc.Alert(
                     [
                         html.I(className="bi bi-info-circle-fill me-2"),
@@ -963,22 +983,15 @@ class LeaseComponents(BaseClass):
                                 {'label': 'No', 'value': False}
                             ],
                             value=True,
-                            inputStyle={
-                                "marginRight": "5px",
-                                "marginLeft": "5px"
-                            },
+                            inputStyle={"marginRight": "5px", "marginLeft": "5px"},
                             inline=True
                         ),
                     ],
                     color="info",
                     style={'marginTop': '5px'}
                 ),
-            ],
-            id={'type': 'dynamic_output_div_lease', 'index': 'listed_date'}
-            ),
-        ],
-        id='listed_date_div'
-        )
+            ], id={'type': 'dynamic_output_div_lease', 'index': 'listed_date'})
+        ], style={'marginBottom': '10px'}, id='listed_date_div_lease')
         
         return listed_date_components
     
@@ -1701,7 +1714,7 @@ class BuyComponents(BaseClass):
                 ], style={'marginBottom': '5px'}),
                 # DatePicker component
                 dcc.DatePickerRange(
-                    id='listed_date_datepicker',
+                    id='listed_date_datepicker_buy',
                     max_date_allowed=today,
                     start_date=self.earliest_date,
                     end_date=today,

--- a/pages/components.py
+++ b/pages/components.py
@@ -1675,21 +1675,37 @@ class BuyComponents(BaseClass):
         today = date.today()
         
         listed_date_components = html.Div([
-            
-            # Title and toggle button
+            # Top header: Listed Date Range with toggle button
             html.Div([
                 html.H5("Listed Date Range", style={'display': 'inline-block', 'marginRight': '10px'}),
                 create_toggle_button(index='listed_date', initial_label="Hide", page_type='buy')
             ]),
-            
-            # DatePicker and Radio button
+            # Main content for listed date
             html.Div([
+                # DatePicker component
                 dcc.DatePickerRange(
                     id='listed_date_datepicker',
                     max_date_allowed=today,
                     start_date=self.earliest_date,
                     end_date=today
                 ),
+                # Header and radio buttons for time range directly underneath
+                html.Div([
+                    html.H6(html.Em("I want to see listings posted in the last..."), style={'marginBottom': '5px'}),
+                    dcc.RadioItems(
+                        id='listed_time_range_radio',
+                        options=[
+                            {'label': '2 Weeks', 'value': 14},
+                            {'label': '1 Month', 'value': 30},
+                            {'label': '3 Months', 'value': 90},
+                            {'label': 'All Time', 'value': 0}
+                        ],
+                        value=0,
+                        inline=True,
+                        labelStyle={'fontSize': '0.8rem', 'marginRight': '10px'}
+                    )
+                ], style={'marginTop': '5px'}),
+                # Alert about missing listed dates
                 dbc.Alert(
                     [
                         html.I(className="bi bi-info-circle-fill me-2"),
@@ -1701,27 +1717,19 @@ class BuyComponents(BaseClass):
                                 {'label': 'No', 'value': False}
                             ],
                             value=True,
-                            inputStyle={
-                                "marginRight": "5px",
-                                "marginLeft": "5px"
-                            },
-                            inline=True     
+                            inputStyle={"marginRight": "5px", "marginLeft": "5px"},
+                            inline=True
                         ),
                     ],
                     color="info",
                     style={'marginTop': '5px'}
                 ),
-            ],
-            id={'type': 'dynamic_output_div_buy', 'index': 'listed_date'}
-            ),
-            
+            ], id={'type': 'dynamic_output_div_buy', 'index': 'listed_date'})
         ],
-        style={
-            'marginBottom': '10px',
-        },
+        style={'marginBottom': '10px'},
         id='listed_date_div_buy'
         )
-
+        
         return listed_date_components
 
     def create_map(self):

--- a/pages/lease_page.py
+++ b/pages/lease_page.py
@@ -34,9 +34,13 @@ geojson_store = dcc.Store(id='lease-geojson-store', storage_type='memory', data=
 #logger.debug(f"GeoJSON data: {geojson_store.data}")
 #logger.debug(f"this is the return geojson {lease_components.return_geojson()}")
 
+# Create a Store to hold the earliest listed date
+earliest_date_store = dcc.Store(id="earliest_date_store", data=lease_components.earliest_date) 
+
 layout = dbc.Container([
   collapse_store,
   geojson_store,
+  earliest_date_store,
   dbc.Row(
     [
       dbc.Col([lease_components.title_card, lease_components.user_options_card], lg=3, md=6, sm=4),
@@ -113,9 +117,20 @@ clientside_callback(
     Input('other_deposit_missing_radio', 'value'),
     Input('laundry_checklist', 'value'),
     Input('subtype_checklist', 'value'),
-    Input('listed_date_datepicker', 'start_date'),
-    Input('listed_date_datepicker', 'end_date'),
+    Input('listed_date_datepicker_lease', 'start_date'),
+    Input('listed_date_datepicker_lease', 'end_date'),
     Input('listed_date_missing_radio', 'value'),
   ],
   State('lease-geojson-store', 'data')
+)
+
+clientside_callback(
+  ClientsideFunction(
+    namespace='clientside',
+    function_name='updateDatePicker'
+  ),
+  Output('listed_date_datepicker_lease', 'start_date'),
+  Input('listed_time_range_radio', 'value'),
+  State('earliest_date_store', 'data'),
+  
 )


### PR DESCRIPTION
Set default month when opening the datepicker to the current month.
Add RadioItems to quickly filter based on set intervals (14d, 30d, 60d, all time)

Resolves #346.