### PR TITLE
Potential fix for code scanning alert no. 41: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,8 +156,8 @@ def report_listing():
     )
     return jsonify(status="success"), 200
   except Exception as e:
-    logger.error("Error sending email:", e)
-    return jsonify(status="error", message=str(e)), 500
+    logger.error("Error sending email: {}", e)
+    return jsonify(status="error", message="An internal error has occurred. Please try again later."), 500
 
 if __name__ == '__main__':
 	app.run(debug=True)


### PR DESCRIPTION
Potential fix for [https://github.com/perfectly-preserved-pie/larentals/security/code-scanning/41](https://github.com/perfectly-preserved-pie/larentals/security/code-scanning/41)

To fix the problem, we should avoid exposing the detailed exception message to the user. Instead, we can log the detailed error message on the server and return a generic error message to the user. This way, developers can still access the detailed error information in the logs, but users will not see potentially sensitive information.

1. Modify the exception handling block to log the detailed error message.
2. Return a generic error message in the JSON response to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
