### PR TITLE
feat(theme): implement color scheme toggle and update dark mode styles

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from dash import Dash, clientside_callback, Input, Output, dcc, ClientsideFunction
+from dash import Dash, clientside_callback, ClientsideFunction, Input, Output, dcc
 from api import register_api_routes
 from dash_extensions import EventListener
 from flask_compress import Compress
@@ -30,6 +30,7 @@ external_scripts = [
 ]
 
 register_filter_exclusion_devtool()
+dmc.pre_render_color_scheme()
 
 # Create the app
 app = Dash(
@@ -136,6 +137,7 @@ app.layout = dmc.MantineProvider(
     create_initial_viewport_sync(),
     create_viewport_listener(),
     create_lahd_records_listener(),
+    dcc.Interval(id="theme-switch-initial-sync", interval=100, n_intervals=0, max_intervals=1),
     dcc.Store(id="theme-switch-store", storage_type="local"),
     create_lahd_records_drawer(),
     dbc.Row( # Second row: the rest
@@ -149,11 +151,16 @@ app.layout = dmc.MantineProvider(
   #html.Link(href='/assets/style.css', rel='stylesheet'),
   ],
   fluid = True,
-  className = "dmc",
+  className = "dmc app-shell",
+  style={"margin": 0, "maxWidth": "none", "minHeight": "100vh", "padding": 0},
   ),
-#forceColorScheme="dark",
 )
 
+clientside_callback(
+  ClientsideFunction(namespace='clientside', function_name='initializeThemeSwitch'),
+  Output("color-scheme-switch", "checked"),
+  Input("theme-switch-initial-sync", "n_intervals"),
+)
 clientside_callback(
   ClientsideFunction(namespace='clientside', function_name='themeSwitch'),
   Output("theme-switch-store", "data"),

--- a/assets/css/dbc-dark-mode.css
+++ b/assets/css/dbc-dark-mode.css
@@ -7,7 +7,7 @@
 }
 
 
-:root[data-bs-theme="dark"] .dbc {
+:root[data-mantine-color-scheme="dark"] .dbc {
     --bs-body-bg: var(--wttl-dark-bg, #191c1e);
     --bs-body-color: var(--wttl-dark-text, #e7ecef);
     --bs-secondary-color: var(--wttl-dark-text-muted, rgba(231, 236, 239, 0.68));
@@ -29,33 +29,42 @@
     --Dash-Text-Weak: rgba(255, 255, 255, 0.3);
 }
 
-:root[data-bs-theme="dark"] .dbc .card {
+:root[data-mantine-color-scheme="dark"] .dbc .card {
+    --bs-card-bg: var(--wttl-dark-panel, #202427);
+    --bs-card-color: var(--wttl-dark-text, #e7ecef);
+    --bs-card-border-color: var(--wttl-dark-border, rgba(232, 238, 241, 0.14));
     background: var(--bs-card-bg);
     border-color: var(--bs-card-border-color);
     color: var(--bs-card-color);
 }
 
-:root[data-bs-theme="dark"] .dbc .card-text,
-:root[data-bs-theme="dark"] .dbc .text-muted {
+:root[data-mantine-color-scheme="dark"] .dbc .title-card .card-title,
+:root[data-mantine-color-scheme="dark"] .dbc .title-card p,
+:root[data-mantine-color-scheme="dark"] .dbc .title-card > .card-body > i {
+    color: var(--wttl-dark-text, #e7ecef);
+}
+
+:root[data-mantine-color-scheme="dark"] .dbc .card-text,
+:root[data-mantine-color-scheme="dark"] .dbc .text-muted {
     color: var(--wttl-dark-text-muted, rgba(231, 236, 239, 0.68)) !important;
 }
 
-:root[data-bs-theme="dark"] .dbc .form-control,
-:root[data-bs-theme="dark"] .dbc .form-select {
+:root[data-mantine-color-scheme="dark"] .dbc .form-control,
+:root[data-mantine-color-scheme="dark"] .dbc .form-select {
     background-color: var(--wttl-dark-input, #2b2f32);
     border-color: var(--wttl-dark-border-strong, rgba(232, 238, 241, 0.24));
     color: var(--wttl-dark-text, #e7ecef);
 }
 
-:root[data-bs-theme="dark"] .dbc .form-control:focus,
-:root[data-bs-theme="dark"] .dbc .form-select:focus {
+:root[data-mantine-color-scheme="dark"] .dbc .form-control:focus,
+:root[data-mantine-color-scheme="dark"] .dbc .form-select:focus {
     background-color: var(--wttl-dark-input, #2b2f32);
     border-color: var(--wttl-dark-accent, #4fc3b4);
     box-shadow: 0 0 0 0.18rem var(--wttl-dark-accent-soft, rgba(79, 195, 180, 0.2));
     color: var(--wttl-dark-text, #e7ecef);
 }
 
-:root[data-bs-theme="dark"] .dbc .btn-primary {
+:root[data-mantine-color-scheme="dark"] .dbc .btn-primary {
     --bs-btn-bg: var(--wttl-dark-accent, #4fc3b4);
     --bs-btn-border-color: var(--wttl-dark-accent, #4fc3b4);
     --bs-btn-hover-bg: #3db2a4;

--- a/assets/css/dmc-dark-mode.css
+++ b/assets/css/dmc-dark-mode.css
@@ -1,5 +1,43 @@
 /* See https://www.dash-mantine-components.com/dash4-components#dark-mode-support
 */
+html,
+body {
+    margin: 0;
+    min-height: 100%;
+    padding: 0;
+}
+
+body {
+    background: var(--mantine-color-body);
+    overflow-x: hidden;
+}
+
+#react-entry-point,
+#_dash-app-content {
+    min-height: 100vh;
+}
+
+.app-shell {
+    background: var(--mantine-color-body);
+    margin: 0;
+    max-width: none;
+    min-height: 100vh;
+    padding: 0;
+    width: 100%;
+}
+
+.theme-switch-control .mantine-Switch-body,
+.theme-switch-control .mantine-Switch-labelWrapper {
+    align-items: center;
+}
+
+.theme-switch-control .mantine-Switch-label {
+    color: var(--mantine-color-gray-6);
+    font-size: 0.95rem;
+    line-height: 1;
+    transform: translateY(1px);
+}
+
 .dmc {
     --Dash-Stroke-Strong: var(--mantine-color-default-border);
     --Dash-Stroke-Weak: var(--mantine-color-disabled);
@@ -11,13 +49,7 @@
     --Dash-Text-Weak: var(--mantine-color-dimmed);
 }
 
-:root[data-mantine-color-scheme="dark"] .dmc {
-    --Dash-Fill-Inverse-Strong: var(--mantine-color-dark-6);
-    --Dash-Fill-Weak: rgba(255, 255, 255, 0.06);
-    --Dash-Fill-Primary-Hover: rgba(255, 255, 255, 0.08);
-    --Dash-Fill-Primary-Active: rgba(255, 255, 255, 0.12);
-    --Dash-Fill-Disabled: rgba(255, 255, 255, 0.15);
-
+:root[data-mantine-color-scheme="dark"] {
     --wttl-dark-bg: #191c1e;
     --wttl-dark-panel: #202427;
     --wttl-dark-section: #252a2d;
@@ -32,7 +64,24 @@
     --wttl-dark-accent: #4fc3b4;
     --wttl-dark-accent-strong: #69d8ca;
     --wttl-dark-accent-soft: rgba(79, 195, 180, 0.2);
+}
 
+:root[data-mantine-color-scheme="dark"] body,
+:root[data-mantine-color-scheme="dark"] .app-shell {
+    background: var(--wttl-dark-bg);
+    color: var(--wttl-dark-text);
+}
+
+:root[data-mantine-color-scheme="dark"] .theme-switch-control .mantine-Switch-label {
+    color: var(--wttl-dark-text-muted);
+}
+
+:root[data-mantine-color-scheme="dark"] .dmc {
+    --Dash-Fill-Inverse-Strong: var(--mantine-color-dark-6);
+    --Dash-Fill-Weak: rgba(255, 255, 255, 0.06);
+    --Dash-Fill-Primary-Hover: rgba(255, 255, 255, 0.08);
+    --Dash-Fill-Primary-Active: rgba(255, 255, 255, 0.12);
+    --Dash-Fill-Disabled: rgba(255, 255, 255, 0.15);
     --Dash-Stroke-Strong: var(--wttl-dark-border-strong);
     --Dash-Stroke-Weak: var(--wttl-dark-border);
     --Dash-Fill-Interactive-Strong: var(--wttl-dark-accent);
@@ -373,6 +422,50 @@
 :root[data-mantine-color-scheme="dark"] .map-gesture-panel-toggle:focus-visible {
     box-shadow: 0 0 0 3px var(--wttl-dark-accent-soft);
     outline: none;
+}
+
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen a,
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen-button,
+:root[data-mantine-color-scheme="dark"] .fullscreen-icon {
+    background-color: var(--wttl-dark-panel);
+    background-image: none !important;
+    color: var(--wttl-dark-text);
+    position: relative;
+}
+
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen a::before,
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen-button::before,
+:root[data-mantine-color-scheme="dark"] .fullscreen-icon::before {
+    border: 2px solid var(--wttl-dark-text);
+    border-bottom-width: 0;
+    border-right-width: 0;
+    content: "";
+    height: 13px;
+    inset: 8px auto auto 8px;
+    position: absolute;
+    width: 13px;
+}
+
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen a::after,
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen-button::after,
+:root[data-mantine-color-scheme="dark"] .fullscreen-icon::after {
+    border: 2px solid var(--wttl-dark-text);
+    border-left-width: 0;
+    border-top-width: 0;
+    content: "";
+    height: 13px;
+    inset: auto 8px 8px auto;
+    position: absolute;
+    width: 13px;
+}
+
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen a:hover::before,
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen a:hover::after,
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen-button:hover::before,
+:root[data-mantine-color-scheme="dark"] .leaflet-control-fullscreen-button:hover::after,
+:root[data-mantine-color-scheme="dark"] .fullscreen-icon:hover::before,
+:root[data-mantine-color-scheme="dark"] .fullscreen-icon:hover::after {
+    border-color: var(--wttl-dark-accent-strong);
 }
 
 :root[data-mantine-color-scheme="dark"] .map-gesture-panel-toggle {

--- a/assets/js/clientside_callbacks/theme_switch.js
+++ b/assets/js/clientside_callbacks/theme_switch.js
@@ -1,9 +1,18 @@
 window.dash_clientside = Object.assign({}, window.dash_clientside, {
   clientside: Object.assign({}, window.dash_clientside && window.dash_clientside.clientside, {
+    initializeThemeSwitch: function() {
+      const storedScheme = localStorage.getItem("mantine-color-scheme-value") || "auto";
+      const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+      return storedScheme === "dark" || (storedScheme === "auto" && prefersDark);
+    },
+
     themeSwitch: function(switchOn) {
-      document.documentElement.setAttribute('data-mantine-color-scheme', switchOn ? 'dark' : 'light');
-      document.documentElement.setAttribute('data-bs-theme', switchOn ? 'dark' : 'light');
-      return switchOn;
+      const scheme = switchOn ? "dark" : "light";
+      document.documentElement.setAttribute("data-mantine-color-scheme", scheme);
+      document.documentElement.classList.remove("auto", "dark", "light");
+      document.documentElement.classList.add(scheme);
+      localStorage.setItem("mantine-color-scheme-value", scheme);
+      return { checked: Boolean(switchOn), colorScheme: scheme };
     }
   })
 });

--- a/pages/buy_components.py
+++ b/pages/buy_components.py
@@ -87,9 +87,9 @@ class BuyComponents(BaseClass):
         subtitle="An interactive map of available residential properties for sale in Los Angeles County. Updated weekly.",
         map_style={
             "width": "100%",
-            "height": "90vh",
-            "margin": "auto",
-            "display": "inline-block",
+            "height": "100vh",
+            "margin": "0",
+            "display": "block",
         },
         active_filter_items=(
             "listed_date",
@@ -100,7 +100,8 @@ class BuyComponents(BaseClass):
             "bathrooms",
         ),
         accordion_class_name="options-accordion",
-        map_card_class_name="d-block d-md-block sticky-top",
+        map_card_class_name="d-block d-md-block sticky-top dbc border-0 rounded-0",
+        map_body_class_name="p-0 g-0 dbc",
     )
 
     @classmethod

--- a/pages/component_factories.py
+++ b/pages/component_factories.py
@@ -302,9 +302,8 @@ def build_title_card(
             ),
             html.Br(),
             dmc.Switch(
-                color="grey",
-                description="Toggle light/dark mode",
                 id="color-scheme-switch",
+                label="Toggle light/dark mode",
                 offLabel=DashIconify(
                     icon="radix-icons:sun",
                     width=15,
@@ -315,14 +314,19 @@ def build_title_card(
                     width=15,
                     color="var(--mantine-color-yellow-6)",
                 ),
+                className="theme-switch-control",
+                color="gray",
+                mt=5,
+                persisted_props=["checked"],
                 persistence=True,
+                persistence_type="local",
                 size="md",
-                style={"marginTop": "5px"},
+                **{"aria-label": "Toggle light/dark mode"},
             ),
         ]
     )
 
-    return dbc.Card(title_card_children, body=True)
+    return dbc.Card(title_card_children, body=True, className="title-card")
 
 
 def build_map(
@@ -515,7 +519,7 @@ def build_map_card(
             body_children,
             style={"position": "relative"},
         ),
-        className=body_class_name,
+        className=body_class_name or "p-0 g-0",
     )
 
     return dbc.Card(body, className=card_class_name)

--- a/pages/lease_components.py
+++ b/pages/lease_components.py
@@ -120,8 +120,8 @@ class LeaseComponents(BaseClass):
             "pet_policy",
         ),
         accordion_class_name="options-accordion dmc",
-        map_card_class_name="d-block d-md-block sticky-top dbc",
-        map_body_class_name="p-2 g-0 dbc",
+        map_card_class_name="d-block d-md-block sticky-top dbc border-0 rounded-0",
+        map_body_class_name="p-0 g-0 dbc",
     )
 
     @classmethod


### PR DESCRIPTION
- Use Mantine color scheme as the theme source of truth
- Restore explicit light/dark switch control with persisted state
- Fix dark-mode Bootstrap card contrast and page edge gutters
- Make map cards flush with the viewport
- Improve dark-mode Leaflet fullscreen control visibility