### PR TITLE
UI redisng - add responsive map filters for rent and buy listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,8 @@ __marimo__/
 .streamlit/secrets.toml
 
 .codex
+
+# Playwright UI test artifacts
+node_modules/
+playwright-report/
+test-results/

--- a/assets/css/responsive-filters.css
+++ b/assets/css/responsive-filters.css
@@ -1,0 +1,600 @@
+:root {
+  --filter-panel-width: clamp(320px, 25vw, 400px);
+  --filter-panel-surface: var(--bs-body-bg, #ffffff);
+  --filter-panel-border: var(--bs-border-color, rgba(15, 23, 42, 0.16));
+  --filter-panel-text: var(--bs-body-color, #172033);
+  --filter-panel-accent: #176b55;
+  --filter-panel-accent-hover: #0f5945;
+  --filter-panel-shadow: 0 24px 70px rgba(15, 23, 42, 0.26);
+}
+
+.listing-page-layout {
+  display: grid;
+  grid-template-columns: var(--filter-panel-width) minmax(0, 1fr);
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow: hidden;
+}
+
+.responsive-filter-panel.options-col {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  min-width: 0;
+  height: 100vh;
+  height: 100dvh;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid var(--filter-panel-border);
+  background: var(--filter-panel-surface);
+  color: var(--filter-panel-text);
+}
+
+.responsive-filter-panel__header,
+.responsive-filter-panel__footer {
+  display: none;
+}
+
+.responsive-filter-panel__body {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.responsive-filter-panel__body > .card,
+.responsive-filter-panel__body > div > .card {
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+}
+
+.listing-map-col.map-col {
+  position: relative;
+  min-width: 0;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.listing-map-col > .card,
+.listing-map-col > .card > .card-body,
+.listing-map-col > .card > .card-body > div {
+  height: 100%;
+}
+
+.filter-panel-backdrop,
+.map-filter-toolbar {
+  display: none;
+}
+
+@media (max-width: 1099.98px) {
+  .listing-page-layout {
+    display: block;
+  }
+
+  .listing-map-col.map-col {
+    width: 100%;
+  }
+
+  .responsive-filter-panel.options-col {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 2400;
+    width: min(440px, 100vw);
+    height: 100vh;
+    height: 100dvh;
+    border: 0;
+    border-left: 1px solid var(--filter-panel-border);
+    border-radius: 22px 0 0 22px;
+    box-shadow: var(--filter-panel-shadow);
+    visibility: hidden;
+    transform: translateX(102%);
+    transition: transform 220ms ease, visibility 0s linear 220ms;
+  }
+
+  .responsive-filter-panel.options-col.is-open {
+    visibility: visible;
+    transform: translateX(0);
+    transition-delay: 0s;
+  }
+
+  .responsive-filter-panel__header {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    min-height: 70px;
+    padding: max(14px, env(safe-area-inset-top)) 18px 12px;
+    border-bottom: 1px solid var(--filter-panel-border);
+    background: var(--filter-panel-surface);
+  }
+
+  .responsive-filter-panel__title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 750;
+    line-height: 1.2;
+  }
+
+  .responsive-filter-panel__title:focus {
+    outline: none;
+  }
+
+  .responsive-filter-panel__count {
+    margin-top: 3px;
+    color: var(--bs-secondary-color, #657084);
+    font-size: 0.85rem;
+  }
+
+  .responsive-filter-panel__close,
+  .map-filter-toolbar__open,
+  .map-filter-chip,
+  .responsive-filter-panel__clear,
+  .responsive-filter-panel__apply {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .responsive-filter-panel__close {
+    display: inline-grid;
+    flex: 0 0 44px;
+    place-items: center;
+    border: 1px solid var(--filter-panel-border);
+    border-radius: 50%;
+    background: transparent;
+    color: inherit;
+    font-size: 1.05rem;
+  }
+
+  .responsive-filter-panel__close:hover,
+  .responsive-filter-panel__close:focus-visible {
+    background: var(--bs-tertiary-bg, #eef1f4);
+  }
+
+  .responsive-filter-panel__body {
+    padding-bottom: 8px;
+    scrollbar-gutter: stable;
+  }
+
+  .responsive-filter-panel__body .title-card .card-body {
+    padding: 12px 16px;
+  }
+
+  .responsive-filter-panel__body .title-card .card-title,
+  .responsive-filter-panel__body .title-card p,
+  .responsive-filter-panel__body .title-card .title-card-links {
+    display: none;
+  }
+
+  .responsive-filter-panel__body .title-card > .card-body > .row {
+    justify-content: space-between;
+    margin: 0;
+  }
+
+  .responsive-filter-panel__body .title-card > .card-body > .row > .col-auto:first-child {
+    display: none;
+  }
+
+  .responsive-filter-panel__body .title-card .btn {
+    min-height: 40px;
+  }
+
+  .responsive-filter-panel__body .card-text:first-child {
+    margin-bottom: 12px;
+  }
+
+  .responsive-filter-panel__body .accordion-button {
+    min-height: 50px;
+    font-weight: 650;
+  }
+
+  .responsive-filter-panel__footer {
+    display: grid;
+    grid-template-columns: minmax(110px, 0.7fr) minmax(190px, 1.3fr);
+    flex: 0 0 auto;
+    gap: 10px;
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+    border-top: 1px solid var(--filter-panel-border);
+    background: color-mix(in srgb, var(--filter-panel-surface) 94%, transparent);
+    box-shadow: 0 -10px 24px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(14px);
+  }
+
+  .responsive-filter-panel__clear,
+  .responsive-filter-panel__apply {
+    border-radius: 12px;
+    padding: 10px 14px;
+    font-weight: 700;
+  }
+
+  .responsive-filter-panel__clear {
+    border: 1px solid var(--filter-panel-border);
+    background: transparent;
+    color: inherit;
+  }
+
+  .responsive-filter-panel__apply {
+    border: 1px solid var(--filter-panel-accent);
+    background: var(--filter-panel-accent);
+    color: #ffffff;
+  }
+
+  .responsive-filter-panel__apply:hover,
+  .responsive-filter-panel__apply:focus-visible {
+    border-color: var(--filter-panel-accent-hover);
+    background: var(--filter-panel-accent-hover);
+  }
+
+  .filter-panel-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 2390;
+    display: block;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: rgba(8, 15, 28, 0.48);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 200ms ease, visibility 0s linear 200ms;
+  }
+
+  .filter-panel-backdrop.is-open {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transition-delay: 0s;
+  }
+
+  body.filter-panel-open {
+    overflow: hidden;
+    touch-action: none;
+  }
+
+  body.filter-panel-open .responsive-filter-panel {
+    touch-action: pan-y;
+  }
+
+  .map-filter-toolbar {
+    position: absolute;
+    top: max(10px, env(safe-area-inset-top));
+    left: 10px;
+    right: 10px;
+    z-index: 1300;
+    display: block;
+    max-width: 760px;
+    margin: 0 auto;
+    color: #172033;
+    pointer-events: none;
+  }
+
+  .map-filter-toolbar__top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 58px;
+    padding: 8px 9px 8px 14px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.18);
+    backdrop-filter: blur(14px);
+    pointer-events: auto;
+  }
+
+  .map-filter-toolbar__identity {
+    min-width: 0;
+  }
+
+  .map-filter-toolbar__brand {
+    display: block;
+    overflow: hidden;
+    color: #15213b;
+    font-size: 0.96rem;
+    font-weight: 800;
+    line-height: 1.2;
+    text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .map-filter-toolbar__result-count {
+    display: block;
+    margin-top: 2px;
+    color: #5c6677;
+    font-size: 0.76rem;
+    line-height: 1.2;
+  }
+
+  .map-filter-toolbar__actions {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .map-filter-toolbar__mode {
+    display: inline-grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3px;
+    padding: 3px;
+    border: 1px solid #cbd3dc;
+    border-radius: 12px;
+    background: #f2f5f7;
+  }
+
+  .map-filter-toolbar__mode-button {
+    display: inline-flex;
+    min-width: 66px;
+    min-height: 38px;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    border: 0;
+    border-radius: 8px;
+    padding: 7px 11px;
+    color: #344054;
+    font-weight: 700;
+    line-height: 1;
+    text-decoration: none;
+  }
+
+  .map-filter-toolbar__mode-button:hover {
+    background: #e5eaee;
+    color: #172033;
+  }
+
+  .map-filter-toolbar__mode-button .bi-check2 {
+    display: none;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .map-filter-toolbar__mode-button.is-selected,
+  .map-filter-toolbar__mode-button.is-selected:hover {
+    background: #176b55;
+    color: #ffffff;
+    box-shadow: 0 2px 6px rgba(23, 107, 85, 0.26);
+  }
+
+  .map-filter-toolbar__mode-button.is-selected .bi-check2 {
+    display: inline-block;
+  }
+
+  .map-filter-toolbar__mode-button:focus-visible {
+    outline: 3px solid rgba(23, 107, 85, 0.3);
+    outline-offset: 2px;
+  }
+
+  .map-filter-toolbar__open {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    border: 1px solid #1a6d58;
+    border-radius: 12px;
+    padding: 8px 12px;
+    background: #176b55;
+    color: #ffffff;
+    font-weight: 750;
+    box-shadow: 0 4px 12px rgba(23, 107, 85, 0.2);
+  }
+
+  .map-filter-toolbar__badge {
+    display: inline-grid;
+    min-width: 21px;
+    height: 21px;
+    place-items: center;
+    border-radius: 999px;
+    background: #ffffff;
+    color: #145442;
+    font-size: 0.72rem;
+    font-weight: 850;
+  }
+
+  .map-filter-toolbar__badge[hidden] {
+    display: none;
+  }
+
+  .map-filter-toolbar__chips {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    padding: 0 2px 5px;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    pointer-events: auto;
+  }
+
+  .map-filter-toolbar__chips::-webkit-scrollbar {
+    display: none;
+  }
+
+  .map-filter-chip {
+    flex: 0 0 auto;
+    border: 1px solid rgba(15, 23, 42, 0.18);
+    border-radius: 999px;
+    padding: 8px 14px;
+    background: rgba(255, 255, 255, 0.97);
+    color: #263349;
+    font-size: 0.84rem;
+    font-weight: 700;
+    line-height: 1;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.13);
+    backdrop-filter: blur(12px);
+  }
+
+  .map-filter-chip--active {
+    border-color: #176b55;
+    background: #e0f4ed;
+    color: #104f3f;
+  }
+
+  .listing-map-col .leaflet-top {
+    top: 128px;
+  }
+
+  .listing-map-col .school-layer-map-prompt {
+    bottom: max(14px, env(safe-area-inset-bottom));
+  }
+}
+
+@media (max-width: 767.98px) {
+  .responsive-filter-panel.options-col {
+    top: auto;
+    left: 0;
+    width: 100%;
+    height: calc(100dvh - 8px);
+    max-height: calc(100dvh - 8px);
+    border-left: 0;
+    border-radius: 22px 22px 0 0;
+    transform: translateY(102%);
+  }
+
+  .responsive-filter-panel.options-col::before {
+    position: absolute;
+    top: 7px;
+    left: 50%;
+    z-index: 1;
+    width: 42px;
+    height: 4px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--filter-panel-text) 30%, transparent);
+    content: "";
+    transform: translateX(-50%);
+  }
+
+  .responsive-filter-panel.options-col.is-open {
+    transform: translateY(0);
+  }
+
+  .responsive-filter-panel__header {
+    padding-top: max(18px, env(safe-area-inset-top));
+  }
+
+  .map-filter-toolbar {
+    left: 8px;
+    right: 8px;
+  }
+
+  .map-filter-toolbar__top {
+    min-height: 56px;
+    border-radius: 16px;
+  }
+
+  .map-filter-toolbar__open {
+    padding-right: 11px;
+    padding-left: 11px;
+  }
+
+  .map-filter-chip {
+    min-height: 42px;
+    padding-right: 13px;
+    padding-left: 13px;
+  }
+
+  .listing-map-col .leaflet-top {
+    top: 126px;
+  }
+}
+
+@media (max-width: 410px) {
+  .map-filter-toolbar__brand {
+    max-width: 128px;
+  }
+
+  .map-filter-toolbar__open > span:not(.map-filter-toolbar__badge) {
+    display: none;
+  }
+}
+
+@media (max-width: 899.98px) and (max-height: 520px) and (orientation: landscape) {
+  .responsive-filter-panel.options-col {
+    height: 100dvh;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .responsive-filter-panel.options-col::before {
+    display: none;
+  }
+
+  .responsive-filter-panel__header {
+    min-height: 58px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .responsive-filter-panel__footer {
+    padding-top: 8px;
+    padding-bottom: max(8px, env(safe-area-inset-bottom));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .responsive-filter-panel.options-col,
+  .filter-panel-backdrop {
+    transition: none;
+  }
+}
+
+:root[data-mantine-color-scheme="dark"] {
+  --filter-panel-surface: var(--wttl-dark-panel, #202427);
+  --filter-panel-border: var(--wttl-dark-border, rgba(232, 238, 241, 0.14));
+  --filter-panel-text: var(--wttl-dark-text, #e7ecef);
+  --filter-panel-accent: var(--wttl-dark-accent, #4fc3b4);
+  --filter-panel-accent-hover: #3db2a4;
+}
+
+:root[data-mantine-color-scheme="dark"] .responsive-filter-panel__apply {
+  color: #10211f;
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__top,
+:root[data-mantine-color-scheme="dark"] .map-filter-chip {
+  border-color: var(--wttl-dark-border, rgba(232, 238, 241, 0.18));
+  background: rgba(32, 36, 39, 0.96);
+  color: var(--wttl-dark-text, #e7ecef);
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__brand {
+  color: var(--wttl-dark-text, #e7ecef);
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__result-count {
+  color: var(--wttl-dark-text-muted, rgba(231, 236, 239, 0.68));
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__mode {
+  border-color: var(--wttl-dark-border, rgba(232, 238, 241, 0.18));
+  background: rgba(13, 17, 19, 0.5);
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__mode-button {
+  color: var(--wttl-dark-text, #e7ecef);
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__mode-button:hover {
+  background: rgba(231, 236, 239, 0.1);
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__mode-button.is-selected,
+:root[data-mantine-color-scheme="dark"] .map-filter-toolbar__mode-button.is-selected:hover {
+  background: var(--wttl-dark-accent, #4fc3b4);
+  color: #10211f;
+}
+
+:root[data-mantine-color-scheme="dark"] .map-filter-chip--active {
+  border-color: var(--wttl-dark-accent, #4fc3b4);
+  background: rgba(79, 195, 180, 0.18);
+  color: #93e6dc;
+}

--- a/assets/js/clientside_callbacks/geojson/filters_buy.js
+++ b/assets/js/clientside_callbacks/geojson/filters_buy.js
@@ -273,3 +273,39 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
         }
     })
 });
+
+window.larentals = window.larentals || {};
+window.larentals.filters = window.larentals.filters || {};
+/**
+ * Adapt the responsive Buy filter-state object to the existing filter engine.
+ * @param {Object<string, *>} state Applied for-sale filter values.
+ * @param {{type: string, features: Array<Object>}} fullGeojson Source listings.
+ * @returns {{type: string, features: Array<Object>}} Filtered Buy listings.
+ */
+window.larentals.filters.filterBuyState = function(state, fullGeojson) {
+    return window.dash_clientside.clientside.filterAndClusterBuy(
+        state.priceRange,
+        state.bedroomsRange,
+        state.bathroomsRange,
+        state.sqftRange,
+        state.sqftMissing,
+        state.ppsqftRange,
+        state.ppsqftMissing,
+        state.lotSizeRange,
+        state.lotSizeMissing,
+        state.yearRange,
+        state.yearMissing,
+        state.subtypes,
+        state.dateStart,
+        state.dateEnd,
+        state.dateMissing,
+        state.hoaRange,
+        state.hoaMissing,
+        state.hoaFrequency,
+        state.downloadRange,
+        state.uploadRange,
+        state.ispMissing,
+        state.zipBoundary,
+        fullGeojson
+    );
+};

--- a/assets/js/clientside_callbacks/geojson/filters_lease.js
+++ b/assets/js/clientside_callbacks/geojson/filters_lease.js
@@ -439,3 +439,52 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
         }
     })
 });
+
+window.larentals = window.larentals || {};
+window.larentals.filters = window.larentals.filters || {};
+/**
+ * Adapt the responsive Rent filter-state object to the existing filter engine.
+ * @param {Object<string, *>} state Applied rental filter values.
+ * @param {{type: string, features: Array<Object>}} fullGeojson Source listings.
+ * @returns {{type: string, features: Array<Object>}} Filtered rental listings.
+ */
+window.larentals.filters.filterLeaseState = function(state, fullGeojson) {
+    return window.dash_clientside.clientside.filterAndClusterLease(
+        state.priceRange,
+        state.bedroomsRange,
+        state.bathroomsRange,
+        state.pets,
+        state.sqftRange,
+        state.sqftMissing,
+        state.ppsqftRange,
+        state.ppsqftMissing,
+        state.parkingRange,
+        state.parkingMissing,
+        state.yearRange,
+        state.yearMissing,
+        state.terms,
+        state.termsMissing,
+        state.furnished,
+        state.furnishedMissing,
+        state.securityRange,
+        state.securityMissing,
+        state.petDepositRange,
+        state.petDepositMissing,
+        state.keyDepositRange,
+        state.keyDepositMissing,
+        state.otherDepositRange,
+        state.otherDepositMissing,
+        state.laundry,
+        state.laundryMissing,
+        state.subtypes,
+        state.dateStart,
+        state.dateEnd,
+        state.dateMissing,
+        state.downloadRange,
+        state.uploadRange,
+        state.ispMissing,
+        state.rentControl,
+        state.zipBoundary,
+        fullGeojson
+    );
+};

--- a/assets/js/clientside_callbacks/layers_control.js
+++ b/assets/js/clientside_callbacks/layers_control.js
@@ -1,4 +1,4 @@
-const LAYERS_CONTROL_MOBILE_BREAKPOINT = 768;
+const LAYERS_CONTROL_COLLAPSE_BREAKPOINT = 1100;
 const VIEWPORT_EVENT_NAME = "viewportchange";
 
 /**
@@ -52,7 +52,7 @@ function setupViewportEvents() {
     /** @type {ViewportDetail} */
     const detail = {
       width,
-      isMobile: width < LAYERS_CONTROL_MOBILE_BREAKPOINT,
+      isMobile: width < LAYERS_CONTROL_COLLAPSE_BREAKPOINT,
     };
 
     if (
@@ -125,7 +125,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
       }
 
       if (typeof window !== "undefined") {
-        return getViewportWidth() < LAYERS_CONTROL_MOBILE_BREAKPOINT;
+        return getViewportWidth() < LAYERS_CONTROL_COLLAPSE_BREAKPOINT;
       }
 
       if (typeof currentCollapsed === "boolean") {

--- a/assets/js/clientside_callbacks/responsive_filters.js
+++ b/assets/js/clientside_callbacks/responsive_filters.js
@@ -1,0 +1,942 @@
+(function () {
+  "use strict";
+
+  /** @typedef {"lease" | "buy"} ListingPage */
+  /** @typedef {Object<string, *>} FilterState */
+  /** @typedef {{type: string, features: Array<Object>}} FeatureCollection */
+
+  const DESKTOP_BREAKPOINT = 1100;
+  const root = window.larentals = window.larentals || {};
+  const filtersApi = root.filters = root.filters || {};
+  const ui = root.responsiveFilters = root.responsiveFilters || {};
+
+  ui.defaults = ui.defaults || {};
+  ui.drafts = ui.drafts || {};
+  ui.applied = ui.applied || {};
+  ui.previewCounts = ui.previewCounts || {};
+  ui.appliedCounts = ui.appliedCounts || {};
+  ui.forceApplyUntil = ui.forceApplyUntil || {};
+  ui.pendingApplyAnalytics = ui.pendingApplyAnalytics || {};
+  ui.pendingLocationApply = ui.pendingLocationApply || {};
+  ui.restoring = ui.restoring || {};
+  ui.openedAt = ui.openedAt || {};
+  ui.pageStartedAt = ui.pageStartedAt || {};
+
+  const CONTROL_MAP = Object.freeze({
+    lease: Object.freeze({
+      priceRange: ["rental_price_slider", "value"],
+      bedroomsRange: ["bedrooms_slider", "value"],
+      bathroomsRange: ["bathrooms_slider", "value"],
+      pets: ["pets_radio", "value"],
+      sqftRange: ["sqft_slider", "value"],
+      sqftMissing: ["sqft_missing_switch", "checked"],
+      ppsqftRange: ["ppsqft_slider", "value"],
+      ppsqftMissing: ["ppsqft_missing_switch", "checked"],
+      parkingRange: ["garage_spaces_slider", "value"],
+      parkingMissing: ["garage_missing_switch", "checked"],
+      yearRange: ["yrbuilt_slider", "value"],
+      yearMissing: ["yrbuilt_missing_switch", "checked"],
+      terms: ["terms_checklist", "value"],
+      termsMissing: ["terms_missing_switch", "checked"],
+      furnished: ["furnished_checklist", "value"],
+      furnishedMissing: ["furnished_missing_switch", "checked"],
+      securityRange: ["security_deposit_slider", "value"],
+      securityMissing: ["security_deposit_missing_switch", "checked"],
+      petDepositRange: ["pet_deposit_slider", "value"],
+      petDepositMissing: ["pet_deposit_missing_switch", "checked"],
+      keyDepositRange: ["key_deposit_slider", "value"],
+      keyDepositMissing: ["key_deposit_missing_switch", "checked"],
+      otherDepositRange: ["other_deposit_slider", "value"],
+      otherDepositMissing: ["other_deposit_missing_switch", "checked"],
+      laundry: ["laundry_checklist", "value"],
+      laundryMissing: ["laundry_missing_switch", "checked"],
+      subtypes: ["subtype_checklist", "value"],
+      listedRange: ["listed_time_range_radio", "value"],
+      dateStart: ["listed_date_datepicker_lease", "start_date"],
+      dateEnd: ["listed_date_datepicker_lease", "end_date"],
+      dateMissing: ["listed_date_missing_switch", "checked"],
+      downloadRange: ["isp_download_speed_slider", "value"],
+      uploadRange: ["isp_upload_speed_slider", "value"],
+      ispMissing: ["isp_speed_missing_switch", "checked"],
+      rentControl: ["rent_control_status", "value"],
+      locationText: ["lease-location-input", "value"],
+      nearbyZip: ["lease-nearby-zip-switch", "checked"],
+      zipBoundary: ["lease-zip-boundary-store", "data"],
+    }),
+    buy: Object.freeze({
+      priceRange: ["list_price_slider", "value"],
+      bedroomsRange: ["bedrooms_slider", "value"],
+      bathroomsRange: ["bathrooms_slider", "value"],
+      sqftRange: ["sqft_slider", "value"],
+      sqftMissing: ["sqft_missing_switch", "checked"],
+      ppsqftRange: ["ppsqft_slider", "value"],
+      ppsqftMissing: ["ppsqft_missing_switch", "checked"],
+      lotSizeRange: ["lot_size_slider", "value"],
+      lotSizeMissing: ["lot_size_missing_switch", "checked"],
+      yearRange: ["yrbuilt_slider", "value"],
+      yearMissing: ["yrbuilt_missing_switch", "checked"],
+      subtypes: ["subtype_checklist", "value"],
+      listedRange: ["listed_time_range_radio", "value"],
+      dateStart: ["listed_date_datepicker_buy", "start_date"],
+      dateEnd: ["listed_date_datepicker_buy", "end_date"],
+      dateMissing: ["listed_date_missing_switch", "checked"],
+      hoaRange: ["hoa_fee_slider", "value"],
+      hoaMissing: ["hoa_fee_missing_switch", "checked"],
+      hoaFrequency: ["hoa_fee_frequency_checklist", "value"],
+      downloadRange: ["isp_download_speed_slider", "value"],
+      uploadRange: ["isp_upload_speed_slider", "value"],
+      ispMissing: ["isp_speed_missing_switch", "checked"],
+      locationText: ["buy-location-input", "value"],
+      nearbyZip: ["buy-nearby-zip-switch", "checked"],
+      zipBoundary: ["buy-zip-boundary-store", "data"],
+    }),
+  });
+
+  const GROUPS = Object.freeze({
+    lease: Object.freeze({
+      location: ["locationText", "nearbyZip"],
+      price: ["priceRange"],
+      bedrooms: ["bedroomsRange"],
+      bathrooms: ["bathroomsRange"],
+      pets: ["pets"],
+      sqft: ["sqftRange", "sqftMissing"],
+      ppsqft: ["ppsqftRange", "ppsqftMissing"],
+      parking: ["parkingRange", "parkingMissing"],
+      year: ["yearRange", "yearMissing"],
+      terms: ["terms", "termsMissing"],
+      furnished: ["furnished", "furnishedMissing"],
+      deposits: [
+        "securityRange", "securityMissing", "petDepositRange",
+        "petDepositMissing", "keyDepositRange", "keyDepositMissing",
+        "otherDepositRange", "otherDepositMissing",
+      ],
+      laundry: ["laundry", "laundryMissing"],
+      subtypes: ["subtypes"],
+      listedDate: ["listedRange", "dateStart", "dateEnd", "dateMissing"],
+      isp: ["downloadRange", "uploadRange", "ispMissing"],
+      rentControl: ["rentControl"],
+    }),
+    buy: Object.freeze({
+      location: ["locationText", "nearbyZip"],
+      price: ["priceRange"],
+      bedrooms: ["bedroomsRange"],
+      bathrooms: ["bathroomsRange"],
+      sqft: ["sqftRange", "sqftMissing"],
+      ppsqft: ["ppsqftRange", "ppsqftMissing"],
+      lotSize: ["lotSizeRange", "lotSizeMissing"],
+      year: ["yearRange", "yearMissing"],
+      subtypes: ["subtypes"],
+      listedDate: ["listedRange", "dateStart", "dateEnd", "dateMissing"],
+      hoa: ["hoaRange", "hoaMissing"],
+      hoaFrequency: ["hoaFrequency"],
+      isp: ["downloadRange", "uploadRange", "ispMissing"],
+    }),
+  });
+
+  /**
+   * Copy a JSON-compatible value without retaining mutable references.
+   * @template T
+   * @param {T} value Value to copy.
+   * @returns {T} Independent copy of the value.
+   */
+  function clone(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  /**
+   * Compare two JSON-compatible values by content.
+   * @param {*} left First value.
+   * @param {*} right Second value.
+   * @returns {boolean} Whether both values serialize identically.
+   */
+  function equal(left, right) {
+    return JSON.stringify(left) === JSON.stringify(right);
+  }
+
+  /**
+   * Identify the listing mode represented by the current URL.
+   * @returns {ListingPage} Current Rent or Buy page key.
+   */
+  function currentPage() {
+    const path = String(window.location && window.location.pathname || "").toLowerCase();
+    return path === "/buy" || path.startsWith("/buy/") ? "buy" : "lease";
+  }
+
+  /**
+   * Read the component IDs that triggered the active Dash callback.
+   * @returns {string[]} Triggering component IDs without property suffixes.
+   */
+  function triggeredIds() {
+    const context = window.dash_clientside && window.dash_clientside.callback_context;
+    if (!context || !Array.isArray(context.triggered)) return [];
+    return context.triggered.map(function (item) {
+      return String(item && item.prop_id || "").split(".")[0];
+    }).filter(Boolean);
+  }
+
+  /**
+   * Find filter groups whose values differ from the page defaults.
+   * @param {ListingPage} page Listing mode to inspect.
+   * @param {FilterState} state Filter values to compare.
+   * @returns {string[]} Names of active filter groups.
+   */
+  function activeGroups(page, state) {
+    const defaults = ui.defaults[page];
+    if (!state || !defaults) return [];
+    return Object.keys(GROUPS[page]).filter(function (groupName) {
+      return GROUPS[page][groupName].some(function (key) {
+        return !equal(state[key], defaults[key]);
+      });
+    });
+  }
+
+  /**
+   * Decide whether captured controls remain a draft or update the map.
+   * @param {ListingPage} page Listing mode being updated.
+   * @param {FilterState} state Newly captured control values.
+   * @param {FilterState | null} currentApplied Last committed filter values.
+   * @returns {Array<*>} Draft and applied values expected by Dash outputs.
+   */
+  function finalizeCapture(page, state, currentApplied) {
+    const ids = triggeredIds();
+    const applyId = `${page}-filter-apply-button`;
+    const zipStoreId = `${page}-zip-boundary-store`;
+    const viewportOnly = ids.length === 1 && ids[0] === "viewport-listener";
+    const isInitial = !currentApplied;
+    const forced = Number(ui.forceApplyUntil[page] || 0) >= Date.now();
+    const pendingLocation = ui.pendingLocationApply[page];
+    const restoring = ui.restoring[page];
+    if (restoring && restoring.expires >= Date.now()) {
+      ui.drafts[page] = clone(restoring.state);
+      scheduleRender(page);
+      return [restoring.state, window.dash_clientside.no_update];
+    }
+    if (restoring) delete ui.restoring[page];
+
+    const completesPendingLocation = Boolean(
+      ids.includes(zipStoreId) &&
+      pendingLocation &&
+      pendingLocation.expires >= Date.now() &&
+      pendingLocation.text === String(state.locationText || "")
+    );
+    const shouldApply = isInitial || window.innerWidth >= DESKTOP_BREAKPOINT ||
+      ids.includes(applyId) || forced || completesPendingLocation;
+
+    if (!ui.defaults[page] || isInitial) {
+      ui.defaults[page] = clone(state);
+    }
+    ui.drafts[page] = clone(state);
+
+    if (currentApplied && !ui.applied[page]) {
+      ui.applied[page] = clone(currentApplied);
+    }
+
+    if (!viewportOnly && page === "lease") {
+      root.analytics?.trackLeaseFilterChanges?.();
+    } else if (!viewportOnly && page === "buy") {
+      root.analytics?.trackBuyFilterChanges?.();
+    }
+
+    if (shouldApply) {
+      ui.applied[page] = clone(state);
+      if (ids.includes(applyId)) {
+        ui.pendingApplyAnalytics[page] = true;
+        if (String(state.locationText || "").trim()) {
+          ui.pendingLocationApply[page] = {
+            text: String(state.locationText || ""),
+            expires: Date.now() + 15_000,
+          };
+        } else {
+          delete ui.pendingLocationApply[page];
+        }
+      }
+      if (completesPendingLocation) {
+        delete ui.pendingLocationApply[page];
+      }
+      scheduleRender(page);
+      return [state, state];
+    }
+
+    scheduleRender(page);
+    return [state, window.dash_clientside.no_update];
+  }
+
+  /**
+   * Run the page-specific filter engine against the source listings.
+   * @param {ListingPage} page Listing mode being filtered.
+   * @param {FilterState} state Filter values to apply.
+   * @param {FeatureCollection} fullGeojson Unfiltered listing features.
+   * @returns {FeatureCollection | null} Filtered features when inputs are ready.
+   */
+  function filterState(page, state, fullGeojson) {
+    if (!state || !fullGeojson || !Array.isArray(fullGeojson.features)) {
+      return null;
+    }
+    if (page === "lease" && typeof filtersApi.filterLeaseState === "function") {
+      return filtersApi.filterLeaseState(state, fullGeojson);
+    }
+    if (page === "buy" && typeof filtersApi.filterBuyState === "function") {
+      return filtersApi.filterBuyState(state, fullGeojson);
+    }
+    return null;
+  }
+
+  /**
+   * Calculate and store the result count for uncommitted filter values.
+   * @param {ListingPage} page Listing mode being previewed.
+   * @param {FilterState} state Draft filter values.
+   * @param {FeatureCollection} fullGeojson Unfiltered listing features.
+   * @returns {{count: number | null, updatedAt?: number}} Preview metadata.
+   */
+  function preview(page, state, fullGeojson) {
+    const result = filterState(page, state, fullGeojson);
+    if (!result) return { count: null };
+    const count = result.features.length;
+    ui.previewCounts[page] = count;
+    scheduleRender(page);
+    return { count, updatedAt: Date.now() };
+  }
+
+  /**
+   * Apply committed filter values and update result-count analytics.
+   * @param {ListingPage} page Listing mode being filtered.
+   * @param {FilterState} state Committed filter values.
+   * @param {FeatureCollection} fullGeojson Unfiltered listing features.
+   * @returns {FeatureCollection | *} Filtered features or Dash's no-update value.
+   */
+  function apply(page, state, fullGeojson) {
+    const result = filterState(page, state, fullGeojson);
+    if (!result) return window.dash_clientside.no_update;
+
+    const count = result.features.length;
+    ui.applied[page] = clone(state);
+    ui.appliedCounts[page] = count;
+
+    if (ui.pendingApplyAnalytics[page]) {
+      ui.pendingApplyAnalytics[page] = false;
+      root.analytics?.trackEvent?.("Filters Applied", {
+        page,
+        ui: "adaptive-sheet-v1",
+        active_filters: activeGroups(page, state).length,
+        results: resultBucket(count),
+      });
+    }
+
+    scheduleRender(page);
+    return result;
+  }
+
+  /**
+   * Reduce an exact result count to a low-cardinality analytics label.
+   * @param {number} count Number of matching listings.
+   * @returns {string} Analytics bucket for the count.
+   */
+  function resultBucket(count) {
+    if (count === 0) return "0";
+    if (count < 10) return "1-9";
+    if (count < 50) return "10-49";
+    if (count < 200) return "50-199";
+    return "200+";
+  }
+
+  /**
+   * Format a numeric value for compact interface copy.
+   * @param {*} value Value that can be converted to a number.
+   * @returns {string} Locale-formatted number.
+   */
+  function formatNumber(value) {
+    return new Intl.NumberFormat("en-US").format(Number(value || 0));
+  }
+
+  /**
+   * Format a price using compact US-dollar notation when appropriate.
+   * @param {*} value Value that can be converted to a number.
+   * @returns {string} Human-readable dollar amount.
+   */
+  function compactCurrency(value) {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) return "$0";
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      notation: Math.abs(amount) >= 1000 ? "compact" : "standard",
+      maximumFractionDigits: 1,
+    }).format(amount);
+  }
+
+  /**
+   * Describe an active numeric range in a quick-filter chip.
+   * @param {string} label Short filter name.
+   * @param {number[]} value Current lower and upper bounds.
+   * @param {number[]} defaults Default lower and upper bounds.
+   * @param {boolean} currency Whether bounds represent currency.
+   * @returns {string} Concise range label.
+   */
+  function rangeLabel(label, value, defaults, currency) {
+    if (!Array.isArray(value) || !Array.isArray(defaults)) return label;
+    const formatter = currency ? compactCurrency : function (number) { return String(number); };
+    if (equal(value, defaults)) return label;
+    if (value[0] === defaults[0]) return `${label} ≤ ${formatter(value[1])} ×`;
+    if (value[1] === defaults[1]) return `${label} ≥ ${formatter(value[0])} ×`;
+    return `${label} ${formatter(value[0])}–${formatter(value[1])} ×`;
+  }
+
+  /**
+   * Update one quick-filter chip to reflect its applied value.
+   * @param {ListingPage} page Listing mode being rendered.
+   * @param {string} group Filter group represented by the chip.
+   * @param {FilterState} state Applied filter values.
+   * @param {FilterState} defaults Default filter values.
+   * @returns {void}
+   */
+  function renderChip(page, group, state, defaults) {
+    const button = document.getElementById(`${page}-quick-${group}`);
+    if (!button) return;
+
+    const active = activeGroups(page, state).includes(group);
+    let text = button.dataset.defaultLabel || button.textContent || group;
+    if (!button.dataset.defaultLabel) button.dataset.defaultLabel = text;
+
+    if (active) {
+      if (group === "location") {
+        const location = String(state.locationText || "Selected area");
+        text = `${location.length > 22 ? `${location.slice(0, 21)}…` : location} ×`;
+      } else if (group === "price") {
+        text = rangeLabel(page === "lease" ? "Rent" : "Price", state.priceRange, defaults.priceRange, true);
+      } else if (group === "bedrooms") {
+        text = rangeLabel("Beds", state.bedroomsRange, defaults.bedroomsRange, false);
+      } else if (group === "bathrooms") {
+        text = rangeLabel("Baths", state.bathroomsRange, defaults.bathroomsRange, false);
+      } else if (group === "pets") {
+        text = `${state.pets === true ? "Pets allowed" : "No pets"} ×`;
+      }
+    }
+
+    button.textContent = text;
+    button.classList.toggle("map-filter-chip--active", active);
+    button.setAttribute(
+      "aria-label",
+      active ? `Remove ${button.dataset.defaultLabel} filter` : `Open ${button.dataset.defaultLabel} filters`
+    );
+  }
+
+  /**
+   * Synchronize toolbar labels, counts, and chips with filter state.
+   * @param {ListingPage} page Listing mode to render.
+   * @returns {void}
+   */
+  function render(page) {
+    const appliedState = ui.applied[page];
+    const defaults = ui.defaults[page];
+    if (!appliedState || !defaults) return;
+
+    const active = activeGroups(page, appliedState);
+    ["location", "price", "bedrooms", "bathrooms"].forEach(function (group) {
+      renderChip(page, group, appliedState, defaults);
+    });
+    if (page === "lease") renderChip(page, "pets", appliedState, defaults);
+
+    const more = document.getElementById(`${page}-quick-more`);
+    const visibleGroups = page === "lease"
+      ? new Set(["location", "price", "bedrooms", "bathrooms", "pets"])
+      : new Set(["location", "price", "bedrooms", "bathrooms"]);
+    const advancedCount = active.filter(function (name) { return !visibleGroups.has(name); }).length;
+    if (more) {
+      more.textContent = advancedCount ? `More · ${advancedCount}` : "More";
+      more.classList.toggle("map-filter-chip--active", advancedCount > 0);
+      more.setAttribute("aria-label", advancedCount ? `Open filters; ${advancedCount} more active` : "Open more filters");
+    }
+
+    const badge = document.getElementById(`${page}-filter-count-badge`);
+    if (badge) {
+      badge.textContent = String(active.length);
+      badge.hidden = active.length === 0;
+    }
+
+    const noun = page === "lease" ? "rentals" : "homes";
+    const appliedCount = ui.appliedCounts[page];
+    const previewCount = ui.previewCounts[page];
+    const mapCount = document.getElementById(`${page}-map-result-count`);
+    if (mapCount && Number.isFinite(appliedCount)) {
+      mapCount.textContent = `${formatNumber(appliedCount)} ${noun}`;
+    }
+
+    const panelCount = document.getElementById(`${page}-filter-panel-count`);
+    if (panelCount && Number.isFinite(previewCount)) {
+      panelCount.textContent = `${formatNumber(previewCount)} matching ${noun}`;
+    }
+
+    const applyButton = document.getElementById(`${page}-filter-apply-button`);
+    if (applyButton && Number.isFinite(previewCount)) {
+      applyButton.textContent = `Show ${formatNumber(previewCount)} ${noun}`;
+      applyButton.setAttribute("aria-label", `Apply filters and show ${formatNumber(previewCount)} matching ${noun}`);
+    }
+  }
+
+  /**
+   * Schedule a toolbar refresh on the browser's next paint.
+   * @param {ListingPage} page Listing mode to render.
+   * @returns {void}
+   */
+  function scheduleRender(page) {
+    window.requestAnimationFrame(function () { render(page); });
+  }
+
+  /**
+   * Write selected filter-state fields back to their Dash controls.
+   * @param {ListingPage} page Listing mode whose controls should change.
+   * @param {FilterState} state Values to restore.
+   * @param {string[]} [keys] State fields to write; defaults to every field.
+   * @returns {void}
+   */
+  function setStateProps(page, state, keys) {
+    if (!state || !window.dash_clientside || typeof window.dash_clientside.set_props !== "function") {
+      return;
+    }
+    const mapping = CONTROL_MAP[page];
+    (keys || Object.keys(mapping)).forEach(function (key) {
+      const target = mapping[key];
+      if (!target || !(key in state)) return;
+      const props = {};
+      props[target[1]] = clone(state[key]);
+      window.dash_clientside.set_props(target[0], props);
+    });
+  }
+
+  /**
+   * Reset one active filter group and immediately update the map.
+   * @param {ListingPage} page Listing mode being changed.
+   * @param {string} group Filter group to reset.
+   * @returns {void}
+   */
+  function removeGroup(page, group) {
+    const defaults = ui.defaults[page];
+    const keys = GROUPS[page] && GROUPS[page][group];
+    if (!defaults || !keys) return;
+    delete ui.restoring[page];
+    ui.forceApplyUntil[page] = Date.now() + 750;
+    setStateProps(page, defaults, keys.concat(group === "location" ? ["zipBoundary"] : []));
+    root.analytics?.trackEvent?.("Applied Filter Removed", { page, filter: group, ui: "adaptive-sheet-v1" });
+  }
+
+  /**
+   * Restore every changed filter control to its page default.
+   * @param {ListingPage} page Listing mode being cleared.
+   * @returns {void}
+   */
+  function clearFilters(page) {
+    const defaults = ui.defaults[page];
+    if (!defaults) return;
+    delete ui.restoring[page];
+    const current = ui.drafts[page] || ui.applied[page] || {};
+    const changedKeys = Object.keys(CONTROL_MAP[page]).filter(function (key) {
+      return !equal(current[key], defaults[key]);
+    });
+    setStateProps(page, defaults, changedKeys);
+    root.analytics?.trackEvent?.("Filters Cleared", { page, ui: "adaptive-sheet-v1" });
+  }
+
+  /**
+   * Find the responsive filter panel for a listing page.
+   * @param {ListingPage} page Listing mode to locate.
+   * @returns {HTMLElement | null} Matching panel, when mounted.
+   */
+  function panelFor(page) {
+    return document.querySelector(`[data-filter-panel='${page}']`);
+  }
+
+  /**
+   * Find every control that can open a page's filter panel.
+   * @param {ListingPage} page Listing mode to locate.
+   * @returns {NodeListOf<HTMLElement>} Matching toolbar and prompt controls.
+   */
+  function toolbarTriggers(page) {
+    return document.querySelectorAll(`[data-filter-open='${page}']`);
+  }
+
+  /**
+   * Open the responsive panel and optionally focus a filter section.
+   * @param {ListingPage} page Listing mode to open.
+   * @param {HTMLElement | null} trigger Control that requested the panel.
+   * @param {string} [section] Accordion section to reveal.
+   * @returns {void}
+   */
+  function openPanel(page, trigger, section) {
+    if (window.innerWidth >= DESKTOP_BREAKPOINT) {
+      focusSection(page, section);
+      return;
+    }
+    const panel = panelFor(page);
+    const backdrop = document.getElementById(`${page}-filter-backdrop`);
+    const main = document.getElementById(`${page}-map-main`);
+    if (!panel || !backdrop) return;
+
+    ui.lastTrigger = trigger || document.activeElement;
+    ui.openedAt[page] = Date.now();
+    panel.classList.add("is-open");
+    backdrop.classList.add("is-open");
+    panel.setAttribute("role", "dialog");
+    panel.setAttribute("aria-modal", "true");
+    document.body.classList.add("filter-panel-open");
+    if (main) main.inert = true;
+    toolbarTriggers(page).forEach(function (item) { item.setAttribute("aria-expanded", "true"); });
+
+    const title = document.getElementById(`${page}-filter-panel-title`);
+    window.setTimeout(function () {
+      (title || panel).focus({ preventScroll: true });
+      focusSection(page, section);
+    }, 180);
+
+    root.analytics?.trackEvent?.("Filter Drawer Opened", {
+      page,
+      source: trigger && trigger.dataset.filterSource || "unknown",
+      presentation: window.innerWidth < 768 ? "bottom-sheet" : "side-drawer",
+      ui: "adaptive-sheet-v1",
+    });
+  }
+
+  /**
+   * Close the responsive panel and optionally discard draft edits.
+   * @param {ListingPage} page Listing mode to close.
+   * @param {string} source Interaction used to close the panel.
+   * @param {boolean} restore Whether applied values should replace the draft.
+   * @returns {void}
+   */
+  function closePanel(page, source, restore) {
+    const panel = panelFor(page);
+    const backdrop = document.getElementById(`${page}-filter-backdrop`);
+    const main = document.getElementById(`${page}-map-main`);
+    if (!panel || !panel.classList.contains("is-open")) return;
+
+    if (restore) {
+      const applied = ui.applied[page] || {};
+      const draft = ui.drafts[page] || {};
+      const locationKeys = new Set(["locationText", "nearbyZip", "zipBoundary"]);
+      const changedKeys = Object.keys(CONTROL_MAP[page]).filter(function (key) {
+        // Local controls are cheap to restore and this closes the rapid-dismiss race.
+        if (!locationKeys.has(key)) return true;
+        // Location changes invoke geocoding callbacks, so only restore them when needed.
+        return !equal(draft[key], applied[key]);
+      });
+      ui.restoring[page] = {
+        state: clone(applied),
+        expires: Date.now() + 350,
+      };
+      ui.drafts[page] = clone(applied);
+      setStateProps(page, applied, changedKeys);
+    }
+    panel.classList.remove("is-open");
+    backdrop?.classList.remove("is-open");
+    panel.setAttribute("role", "complementary");
+    panel.removeAttribute("aria-modal");
+    document.body.classList.remove("filter-panel-open");
+    if (main) main.inert = false;
+    toolbarTriggers(page).forEach(function (item) { item.setAttribute("aria-expanded", "false"); });
+
+    const duration = ui.openedAt[page] ? Math.round((Date.now() - ui.openedAt[page]) / 1000) : 0;
+    root.analytics?.trackEvent?.("Filter Drawer Closed", {
+      page,
+      source,
+      duration: duration < 10 ? "0-9s" : duration < 30 ? "10-29s" : "30s+",
+      ui: "adaptive-sheet-v1",
+    });
+
+    const focusTarget = ui.lastTrigger;
+    if (focusTarget && typeof focusTarget.focus === "function" && focusTarget.isConnected) {
+      window.setTimeout(function () { focusTarget.focus(); }, 160);
+    }
+  }
+
+  const SECTION_LABELS = Object.freeze({
+    listed_date: "Listed Date",
+    location: "Location",
+    subtypes: "Subtypes",
+    monthly_rent: "Monthly Rent",
+    list_price: "List Price",
+    bedrooms: "Bedrooms",
+    bathrooms: "Bathrooms",
+    pet_policy: "Pet Policy",
+  });
+
+  /**
+   * Scroll to and focus a named filter accordion section.
+   * @param {ListingPage} page Listing mode containing the accordion.
+   * @param {string} [section] Section key to focus.
+   * @returns {void}
+   */
+  function focusSection(page, section) {
+    if (!section) return;
+    const accordion = document.getElementById(`${page}-options-accordion`);
+    const expected = SECTION_LABELS[section];
+    if (!accordion || !expected) return;
+    window.setTimeout(function () {
+      const button = Array.from(accordion.querySelectorAll(".accordion-button")).find(function (item) {
+        return String(item.textContent || "").trim() === expected;
+      });
+      if (!button) return;
+      button.scrollIntoView({ behavior: "smooth", block: "start" });
+      button.focus({ preventScroll: true });
+    }, 220);
+  }
+
+  /**
+   * Route delegated clicks to open, close, apply, clear, or remove actions.
+   * @param {MouseEvent} event Captured document click.
+   * @returns {void}
+   */
+  function clickHandler(event) {
+    const openTrigger = event.target.closest("[data-filter-open]");
+    if (openTrigger) {
+      const page = openTrigger.dataset.filterOpen;
+      const group = openTrigger.dataset.filterGroup;
+      if (group && openTrigger.classList.contains("map-filter-chip--active")) {
+        event.preventDefault();
+        removeGroup(page, group);
+        return;
+      }
+      openPanel(page, openTrigger, openTrigger.dataset.filterSection);
+      return;
+    }
+
+    const clearTrigger = event.target.closest("[data-filter-clear]");
+    if (clearTrigger) {
+      clearFilters(clearTrigger.dataset.filterClear);
+      return;
+    }
+
+    const applyTrigger = event.target.closest("[data-filter-apply]");
+    if (applyTrigger) {
+      const page = applyTrigger.dataset.filterApply;
+      closePanel(page, "apply", false);
+      return;
+    }
+
+    const closeTrigger = event.target.closest("[data-filter-close]");
+    if (closeTrigger) {
+      closePanel(
+        closeTrigger.dataset.filterClose,
+        closeTrigger.dataset.filterCloseSource || "dismiss",
+        true
+      );
+    }
+  }
+
+  /**
+   * Collect visible controls that participate in the panel's focus trap.
+   * @param {HTMLElement} panel Open filter panel.
+   * @returns {HTMLElement[]} Visible keyboard-focusable descendants.
+   */
+  function focusableElements(panel) {
+    return Array.from(panel.querySelectorAll(
+      "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), " +
+      "textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"
+    )).filter(function (element) {
+      return !element.hidden && element.getClientRects().length > 0;
+    });
+  }
+
+  /**
+   * Handle Escape dismissal and Tab wrapping inside an open panel.
+   * @param {KeyboardEvent} event Document keyboard event.
+   * @returns {void}
+   */
+  function keyHandler(event) {
+    const page = currentPage();
+    const panel = panelFor(page);
+    if (!panel || !panel.classList.contains("is-open")) return;
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closePanel(page, "escape", true);
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+    const focusable = focusableElements(panel);
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  /**
+   * Reset modal-only state when the viewport enters desktop mode.
+   * @returns {void}
+   */
+  function syncBreakpoint() {
+    ["lease", "buy"].forEach(function (page) {
+      const panel = panelFor(page);
+      const main = document.getElementById(`${page}-map-main`);
+      if (!panel) return;
+      if (window.innerWidth >= DESKTOP_BREAKPOINT) {
+        panel.classList.remove("is-open");
+        document.getElementById(`${page}-filter-backdrop`)?.classList.remove("is-open");
+        panel.setAttribute("role", "complementary");
+        panel.removeAttribute("aria-modal");
+        if (main) main.inert = false;
+      }
+    });
+    if (window.innerWidth >= DESKTOP_BREAKPOINT) {
+      document.body.classList.remove("filter-panel-open");
+    }
+  }
+
+  /**
+   * Attach one-time analytics after the Leaflet map becomes available.
+   * @returns {void}
+   */
+  function attachFirstMapInteraction() {
+    const page = currentPage();
+    ui.pageStartedAt[page] = ui.pageStartedAt[page] || Date.now();
+    let attempts = 0;
+    const timer = window.setInterval(function () {
+      attempts += 1;
+      const map = root.mapGestureControls?.getMap?.();
+      if (!map && attempts < 30) return;
+      window.clearInterval(timer);
+      if (!map || map.__adaptiveFilterAnalyticsBound) return;
+      map.__adaptiveFilterAnalyticsBound = true;
+      map.once("movestart zoomstart click", function () {
+        const seconds = Math.round((Date.now() - ui.pageStartedAt[page]) / 1000);
+        root.analytics?.trackEvent?.("First Map Interaction", {
+          page,
+          elapsed: seconds < 5 ? "0-4s" : seconds < 15 ? "5-14s" : seconds < 45 ? "15-44s" : "45s+",
+          ui: "adaptive-sheet-v1",
+        });
+      });
+    }, 300);
+  }
+
+  ui.render = render;
+  ui.restore = setStateProps;
+
+  window.dash_clientside = Object.assign({}, window.dash_clientside, {
+    clientside: Object.assign({}, window.dash_clientside && window.dash_clientside.clientside, {
+      /**
+       * Capture rental controls in Dash callback order and stage or apply them.
+       * @returns {Array<*>} Draft and applied values for the callback outputs.
+       */
+      captureLeaseFilterState: function (
+        priceRange, bedroomsRange, bathroomsRange, pets,
+        sqftRange, sqftMissing, ppsqftRange, ppsqftMissing,
+        parkingRange, parkingMissing, yearRange, yearMissing,
+        terms, termsMissing, furnished, furnishedMissing,
+        securityRange, securityMissing, petDepositRange, petDepositMissing,
+        keyDepositRange, keyDepositMissing, otherDepositRange, otherDepositMissing,
+        laundry, laundryMissing, subtypes, listedRange, dateStart, dateEnd,
+        dateMissing, downloadRange, uploadRange, ispMissing, rentControl,
+        locationText, nearbyZip, zipBoundary, _applyClicks, _viewport, currentApplied
+      ) {
+        return finalizeCapture("lease", {
+          priceRange, bedroomsRange, bathroomsRange, pets,
+          sqftRange, sqftMissing, ppsqftRange, ppsqftMissing,
+          parkingRange, parkingMissing, yearRange, yearMissing,
+          terms, termsMissing, furnished, furnishedMissing,
+          securityRange, securityMissing, petDepositRange, petDepositMissing,
+          keyDepositRange, keyDepositMissing, otherDepositRange, otherDepositMissing,
+          laundry, laundryMissing, subtypes, listedRange, dateStart, dateEnd,
+          dateMissing, downloadRange, uploadRange, ispMissing, rentControl,
+          locationText, nearbyZip, zipBoundary,
+        }, currentApplied);
+      },
+
+      /**
+       * Capture for-sale controls in Dash callback order and stage or apply them.
+       * @returns {Array<*>} Draft and applied values for the callback outputs.
+       */
+      captureBuyFilterState: function (
+        priceRange, bedroomsRange, bathroomsRange,
+        sqftRange, sqftMissing, ppsqftRange, ppsqftMissing,
+        lotSizeRange, lotSizeMissing, yearRange, yearMissing,
+        subtypes, listedRange, dateStart, dateEnd, dateMissing,
+        hoaRange, hoaMissing, hoaFrequency,
+        downloadRange, uploadRange, ispMissing,
+        locationText, nearbyZip, zipBoundary, _applyClicks, _viewport, currentApplied
+      ) {
+        return finalizeCapture("buy", {
+          priceRange, bedroomsRange, bathroomsRange,
+          sqftRange, sqftMissing, ppsqftRange, ppsqftMissing,
+          lotSizeRange, lotSizeMissing, yearRange, yearMissing,
+          subtypes, listedRange, dateStart, dateEnd, dateMissing,
+          hoaRange, hoaMissing, hoaFrequency,
+          downloadRange, uploadRange, ispMissing,
+          locationText, nearbyZip, zipBoundary,
+        }, currentApplied);
+      },
+
+      /**
+       * Preview the number of rentals matching draft values.
+       * @param {FilterState} state Draft rental filters.
+       * @param {FeatureCollection} fullGeojson Source rental listings.
+       * @returns {{count: number | null, updatedAt?: number}} Preview metadata.
+       */
+      previewLeaseFilterState: function (state, fullGeojson) {
+        return preview("lease", state, fullGeojson);
+      },
+      /**
+       * Preview the number of homes matching draft values.
+       * @param {FilterState} state Draft for-sale filters.
+       * @param {FeatureCollection} fullGeojson Source for-sale listings.
+       * @returns {{count: number | null, updatedAt?: number}} Preview metadata.
+       */
+      previewBuyFilterState: function (state, fullGeojson) {
+        return preview("buy", state, fullGeojson);
+      },
+      /**
+       * Apply committed rental filters to the map data.
+       * @param {FilterState} state Applied rental filters.
+       * @param {FeatureCollection} fullGeojson Source rental listings.
+       * @returns {FeatureCollection | *} Filtered data or Dash's no-update value.
+       */
+      applyLeaseFilterState: function (state, fullGeojson) {
+        return apply("lease", state, fullGeojson);
+      },
+      /**
+       * Apply committed for-sale filters to the map data.
+       * @param {FilterState} state Applied for-sale filters.
+       * @param {FeatureCollection} fullGeojson Source for-sale listings.
+       * @returns {FeatureCollection | *} Filtered data or Dash's no-update value.
+       */
+      applyBuyFilterState: function (state, fullGeojson) {
+        return apply("buy", state, fullGeojson);
+      },
+
+      /**
+       * Add the quick-filter target to the accordion's expanded sections.
+       * @returns {string[] | *} Expanded section keys or Dash's no-update value.
+       */
+      openFilterAccordionSection: function () {
+        const args = Array.prototype.slice.call(arguments);
+        const current = Array.isArray(args[args.length - 1]) ? args[args.length - 1] : [];
+        const id = triggeredIds()[0] || "";
+        const page = id.startsWith("buy-") ? "buy" : "lease";
+        const button = document.getElementById(id);
+        if (button?.classList.contains("map-filter-chip--active")) {
+          return window.dash_clientside.no_update;
+        }
+        const section = button?.dataset.filterSection;
+        if (!section) return window.dash_clientside.no_update;
+        return current.includes(section) ? current : current.concat(section);
+      },
+    }),
+  });
+
+  // Capture the interaction before Dash's React handlers consume component clicks.
+  document.addEventListener("click", clickHandler, true);
+  document.addEventListener("keydown", keyHandler);
+  window.addEventListener("resize", syncBreakpoint, { passive: true });
+  window.addEventListener("orientationchange", syncBreakpoint, { passive: true });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", attachFirstMapInteraction, { once: true });
+  } else {
+    attachFirstMapInteraction();
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "wheretolive-la-ui-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wheretolive-la-ui-tests",
+      "devDependencies": {
+        "@playwright/test": "1.62.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "wheretolive-la-ui-tests",
+  "private": true,
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/pages/buy_components.py
+++ b/pages/buy_components.py
@@ -18,6 +18,7 @@ from .component_factories import (
     build_year_built_filter,
 )
 from .component_models import FilterSection, PageConfig, PageParts
+from .responsive_filter_ui import build_map_filter_toolbar
 
 
 class BuyComponents(BaseClass):
@@ -88,17 +89,14 @@ class BuyComponents(BaseClass):
         subtitle="An interactive map of available residential properties for sale in Los Angeles County. Updated weekly.",
         map_style={
             "width": "100%",
-            "height": "100vh",
+            "height": "100dvh",
             "margin": "0",
             "display": "block",
         },
         active_filter_items=(
-            "listed_date",
             "location",
-            "subtypes",
             "list_price",
             "bedrooms",
-            "bathrooms",
         ),
         accordion_class_name="options-accordion",
         map_card_class_name="d-block d-md-block sticky-top dbc border-0 rounded-0",
@@ -148,6 +146,7 @@ class BuyComponents(BaseClass):
             filter_items=self._build_filter_sections(),
             map_component=self._build_map_component(),
             map_overlay_children=[
+                build_map_filter_toolbar(self.page_type),
                 build_map_gesture_control(),
                 build_school_layer_map_prompt(self.page_type),
             ],

--- a/pages/buy_page.py
+++ b/pages/buy_page.py
@@ -18,6 +18,11 @@ from functions.zip_geocoding_utils import (
 )
 from functions.sql_helpers import get_earliest_listed_date
 from functions.data_paths import LARENTALS_DB_PATH, SOCAL_SERVICE_AREA_ZIP_CODES_PATH, ZIP_PLACE_CROSSWALK_PATH
+from .responsive_filter_ui import (
+  build_filter_ui_stores,
+  build_responsive_listing_shell,
+  register_responsive_filter_callbacks,
+)
 from dash.dependencies import ALL, Input, Output, State
 from loguru import logger
 import bleach
@@ -67,7 +72,6 @@ def layout(**_: object) -> dbc.Container:
     The buy page layout container.
   """
   components = get_buy_components()
-  collapse_store = dcc.Store(id="collapse-store", data={"is_open": False})
   geojson_store = dcc.Store(id="buy-geojson-store", storage_type="memory", data=None)
   zip_boundary_store = dcc.Store(id="buy-zip-boundary-store", storage_type="memory", data={"zip_codes": [], "features": [], "error": None})
   school_layer_prompt_state_store = dcc.Store(
@@ -105,7 +109,7 @@ def layout(**_: object) -> dbc.Container:
 
   return dbc.Container(
     [
-      collapse_store,
+      *build_filter_ui_stores("buy"),
       geojson_store,
       zip_boundary_store,
       school_layer_prompt_state_store,
@@ -116,23 +120,11 @@ def layout(**_: object) -> dbc.Container:
       analytics_school_filter_store,
       kickstart,
       earliest_date_store,
-      dbc.Row(
-        [
-          dbc.Col(
-          [components.title_card, components.user_options_card], 
-            lg=3, md=12, sm=12, xs=12,
-            style={"height": "100vh", "overflowY": "auto"},  # Full height with scroll on desktop
-            className="d-lg-block"  # Always visible on desktop
-        ),
-          dbc.Col(
-          [components.map_card], 
-            lg=9, md=12, sm=12, xs=12,
-            style={"height": "100vh"},  # Full viewport height
-            className="position-lg-relative"
-          ),
-        ],
-        className="g-0",
-        style={"minHeight": "100vh"}
+      build_responsive_listing_shell(
+        page_type="buy",
+        title_card=components.title_card,
+        user_options_card=components.user_options_card,
+        map_card=components.map_card,
       ),
       # Keep the subtype selection available for any future callbacks that need it.
       dcc.Store(id='selected_subtype', data=[])
@@ -141,6 +133,9 @@ def layout(**_: object) -> dbc.Container:
     className="dbc p-0",
     style={"overflowX": "hidden"}  # Prevent horizontal scroll
   )
+
+
+register_responsive_filter_callbacks("buy")
 
 ## BEGIN CALLBACKS ##
 # Keep subtype selection in sync with the store
@@ -579,39 +574,6 @@ clientside_callback(
   State(LayersClass.layers_control_id("buy"), "overlays"),
   State({"type": "lazy-layer-geojson", "page": "buy", "layer": ALL}, "id"),
   prevent_initial_call=True,
-)
-
-clientside_callback(
-  ClientsideFunction(
-    namespace='clientside',
-    function_name='filterAndClusterBuy'
-  ),
-  Output('buy_geojson', 'data'),
-  [
-    Input('list_price_slider', 'value'),
-    Input('bedrooms_slider', 'value'),
-    Input('bathrooms_slider', 'value'),
-    Input('sqft_slider', 'value'),
-    Input('sqft_missing_switch', 'checked'),
-    Input('ppsqft_slider', 'value'),
-    Input('ppsqft_missing_switch', 'checked'),
-    Input('lot_size_slider', 'value'),
-    Input('lot_size_missing_switch', 'checked'),
-    Input('yrbuilt_slider', 'value'),
-    Input('yrbuilt_missing_switch', 'checked'),
-    Input('subtype_checklist', 'value'),
-    Input('listed_date_datepicker_buy', 'start_date'),
-    Input('listed_date_datepicker_buy', 'end_date'),
-    Input('listed_date_missing_switch', 'checked'),
-    Input('hoa_fee_slider', 'value'),
-    Input('hoa_fee_missing_switch', 'checked'),
-    Input('hoa_fee_frequency_checklist', 'value'),
-    Input('isp_download_speed_slider', 'value'),
-    Input('isp_upload_speed_slider', 'value'),
-    Input('isp_speed_missing_switch', 'checked'),
-    Input('buy-zip-boundary-store', 'data'),
-    Input('buy-geojson-store', "data")
-  ],
 )
 
 clientside_callback(

--- a/pages/component_factories.py
+++ b/pages/component_factories.py
@@ -617,12 +617,15 @@ def build_school_layer_map_prompt(page_type: str) -> html.Div:
                 ),
                 html.Div(
                     [
-                        dbc.Button(
+                        html.Button(
                             "Show filters",
                             id=f"{prefix}-show-filters-button",
-                            color="success",
-                            size="sm",
-                            className="school-layer-map-prompt__button",
+                            type="button",
+                            className="btn btn-success btn-sm school-layer-map-prompt__button",
+                            **{
+                                "data-filter-open": page_type,
+                                "data-filter-source": "school-prompt",
+                            },
                         ),
                         dbc.Button(
                             "Dismiss",

--- a/pages/component_factories.py
+++ b/pages/component_factories.py
@@ -176,11 +176,16 @@ def build_location_filter_components(page_type: str) -> html.Div:
     """
     return html.Div(
         [
+            html.Label(
+                "Filter listings by neighborhood or ZIP code",
+                htmlFor=f"{page_type}-location-input",
+                className="visually-hidden",
+            ),
             dcc.Input(
                 id=f"{page_type}-location-input",
                 type="text",
                 debounce=True,
-                placeholder="Neighborhood or ZIP code (e.g., Highland Park or 90042)",
+                placeholder="Neighborhood or ZIP code",
             ),
             html.Div(
                 id=f"{page_type}-location-status",

--- a/pages/lease_components.py
+++ b/pages/lease_components.py
@@ -23,6 +23,7 @@ from .component_factories import (
     build_year_built_filter,
 )
 from .component_models import FilterSection, PageConfig, PageParts
+from .responsive_filter_ui import build_map_filter_toolbar
 from functions.rso import add_rso_status_to_listing_geojson
 
 
@@ -109,19 +110,14 @@ class LeaseComponents(BaseClass):
         subtitle="An interactive map of available rentals in Los Angeles County. Updated weekly.",
         map_style={
             "width": "100%",
-            "height": "100vh",
+            "height": "100dvh",
             "margin": "0",
             "display": "block",
         },
         active_filter_items=(
-            "listed_date",
             "location",
-            "subtypes",
             "monthly_rent",
-            "rent_control",
             "bedrooms",
-            "bathrooms",
-            "pet_policy",
         ),
         accordion_class_name="options-accordion dmc",
         map_card_class_name="d-block d-md-block sticky-top dbc border-0 rounded-0",
@@ -176,6 +172,7 @@ class LeaseComponents(BaseClass):
             filter_items=self._build_filter_sections(),
             map_component=self._build_map_component(),
             map_overlay_children=[
+                build_map_filter_toolbar(self.page_type),
                 build_map_gesture_control(),
                 build_school_layer_map_prompt(self.page_type),
             ],

--- a/pages/lease_page.py
+++ b/pages/lease_page.py
@@ -19,6 +19,11 @@ from functions.zip_geocoding_utils import (
 )
 from functions.sql_helpers import get_earliest_listed_date
 from functions.data_paths import LARENTALS_DB_PATH, SOCAL_SERVICE_AREA_ZIP_CODES_PATH, ZIP_PLACE_CROSSWALK_PATH
+from .responsive_filter_ui import (
+  build_filter_ui_stores,
+  build_responsive_listing_shell,
+  register_responsive_filter_callbacks,
+)
 from loguru import logger
 import bleach
 import dash
@@ -66,7 +71,6 @@ def layout(**_: object) -> dbc.Container:
   """
   lease_components = get_lease_components()
 
-  collapse_store = dcc.Store(id="collapse-store", data={"is_open": False})
   geojson_store = dcc.Store(id="lease-geojson-store", storage_type="memory", data=None)
   zip_boundary_store = dcc.Store(id="lease-zip-boundary-store", storage_type="memory", data={"zip_codes": [], "features": [], "error": None})
   school_layer_prompt_state_store = dcc.Store(
@@ -105,7 +109,7 @@ def layout(**_: object) -> dbc.Container:
 
   return dbc.Container(
     [
-      collapse_store,
+      *build_filter_ui_stores("lease"),
       geojson_store,
       zip_boundary_store,
       school_layer_prompt_state_store,
@@ -116,27 +120,20 @@ def layout(**_: object) -> dbc.Container:
       analytics_school_filter_store,
       kickstart,
       earliest_date_store,
-      dbc.Row(
-        [
-          dbc.Col(
-            [lease_components.title_card, lease_components.user_options_card], 
-            lg=3, md=12, sm=12, xs=12,
-            className="options-col d-lg-block",  # Always visible on desktop
-          ),
-          dbc.Col(
-            [lease_components.map_card], 
-            lg=9, md=12, sm=12, xs=12,
-            className="map-col position-lg-relative"
-          ),
-        ],
-        className="g-0",
-        style={"minHeight": "100vh"}
+      build_responsive_listing_shell(
+        page_type="lease",
+        title_card=lease_components.title_card,
+        user_options_card=lease_components.user_options_card,
+        map_card=lease_components.map_card,
       ),
     ],
     fluid=True,
     className="dbc p-0",
     style={"overflowX": "hidden"}  # Prevent horizontal scroll
   )
+
+
+register_responsive_filter_callbacks("lease")
 
 # Server-side callbacks
 @callback(
@@ -561,52 +558,6 @@ clientside_callback(
   State(LayersClass.layers_control_id("lease"), "overlays"),
   State({"type": "lazy-layer-geojson", "page": "lease", "layer": ALL}, "id"),
   prevent_initial_call=True,
-)
-
-clientside_callback(
-  ClientsideFunction(
-    namespace='clientside',
-    function_name='filterAndClusterLease'
-  ),
-  Output('lease_geojson', 'data'),
-  [ # The order of these inputs must match the order of the arguments in the filterAndCluster function
-    Input('rental_price_slider', 'value'),
-    Input('bedrooms_slider', 'value'),
-    Input('bathrooms_slider', 'value'),
-    Input('pets_radio', 'value'),
-    Input('sqft_slider', 'value'),
-    Input('sqft_missing_switch', 'checked'),
-    Input('ppsqft_slider', 'value'),
-    Input('ppsqft_missing_switch', 'checked'),
-    Input('garage_spaces_slider', 'value'),
-    Input('garage_missing_switch', 'checked'),
-    Input('yrbuilt_slider', 'value'),
-    Input('yrbuilt_missing_switch', 'checked'),
-    Input('terms_checklist', 'value'),
-    Input('terms_missing_switch', 'checked'),
-    Input('furnished_checklist', 'value'),
-    Input('furnished_missing_switch', 'checked'),
-    Input('security_deposit_slider', 'value'),
-    Input('security_deposit_missing_switch', 'checked'),
-    Input('pet_deposit_slider', 'value'),
-    Input('pet_deposit_missing_switch', 'checked'),
-    Input('key_deposit_slider', 'value'),
-    Input('key_deposit_missing_switch', 'checked'),
-    Input('other_deposit_slider', 'value'),
-    Input('other_deposit_missing_switch', 'checked'),
-    Input('laundry_checklist', 'value'),
-    Input('laundry_missing_switch', 'checked'),
-    Input('subtype_checklist', 'value'),
-    Input('listed_date_datepicker_lease', 'start_date'),
-    Input('listed_date_datepicker_lease', 'end_date'),
-    Input('listed_date_missing_switch', 'checked'),
-    Input('isp_download_speed_slider', 'value'),
-    Input('isp_upload_speed_slider', 'value'),
-    Input('isp_speed_missing_switch', 'checked'),
-    Input('rent_control_status', 'value'),
-    Input('lease-zip-boundary-store', 'data'),
-    Input('lease-geojson-store', "data"),
-  ],
 )
 
 clientside_callback(

--- a/pages/responsive_filter_ui.py
+++ b/pages/responsive_filter_ui.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+from dash import ClientsideFunction, Input, Output, State, clientside_callback, dcc, html
+from dash.development.base_component import Component
+import dash_bootstrap_components as dbc
+
+
+FILTER_UI_BREAKPOINT = 1100
+
+
+def build_filter_ui_stores(page_type: str) -> list[dcc.Store]:
+    """
+    Create the client-side stores used by a listing page's filters.
+
+    The stores keep draft values, applied values, and the preview result count
+    separate so mobile users can cancel edits without changing the map.
+    """
+    return [
+        dcc.Store(id=f"{page_type}-filter-draft-store", storage_type="memory"),
+        dcc.Store(id=f"{page_type}-filter-applied-store", storage_type="memory"),
+        dcc.Store(
+            id=f"{page_type}-filter-preview-store",
+            storage_type="memory",
+            data={"count": None},
+        ),
+    ]
+
+
+def build_map_filter_toolbar(page_type: str) -> html.Div:
+    """
+    Build the compact toolbar shown over the map on smaller screens.
+
+    ``page_type`` selects the Rent or Buy labels, links, and quick-filter chips.
+    The toolbar itself is hidden when the persistent desktop sidebar is visible.
+    """
+    price_label = "Monthly rent" if page_type == "lease" else "List price"
+    price_section = "monthly_rent" if page_type == "lease" else "list_price"
+    listing_label = "rentals" if page_type == "lease" else "homes"
+
+    chips: list[Component] = [
+        _quick_filter_button(page_type, "location", "Location", "location"),
+        _quick_filter_button(page_type, "price", price_label, price_section),
+        _quick_filter_button(page_type, "bedrooms", "Beds", "bedrooms"),
+        _quick_filter_button(page_type, "bathrooms", "Baths", "bathrooms"),
+    ]
+    if page_type == "lease":
+        chips.append(
+            _quick_filter_button(page_type, "pets", "Pets", "pet_policy")
+        )
+    chips.append(
+        html.Button(
+            "More",
+            id=f"{page_type}-quick-more",
+            type="button",
+            className="map-filter-chip map-filter-chip--more",
+            **{
+                "data-filter-open": page_type,
+                "data-filter-source": "more-chip",
+                "aria-controls": f"{page_type}-filter-panel",
+            },
+        )
+    )
+
+    return html.Div(
+        [
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.A(
+                                "WhereToLive.LA",
+                                href="/" if page_type == "lease" else "/buy",
+                                className="map-filter-toolbar__brand",
+                            ),
+                            html.Span(
+                                f"0 {listing_label}",
+                                id=f"{page_type}-map-result-count",
+                                className="map-filter-toolbar__result-count",
+                                **{"aria-live": "polite"},
+                            ),
+                        ],
+                        className="map-filter-toolbar__identity",
+                    ),
+                    html.Div(
+                        [
+                            html.Nav(
+                                [
+                                    html.A(
+                                        [
+                                            html.I(
+                                                className="bi bi-check2",
+                                                **{"aria-hidden": "true"},
+                                            ),
+                                            html.Span("Rent"),
+                                        ],
+                                        href="/",
+                                        className=(
+                                            "map-filter-toolbar__mode-button is-selected"
+                                            if page_type == "lease"
+                                            else "map-filter-toolbar__mode-button"
+                                        ),
+                                        **(
+                                            {"aria-current": "page"}
+                                            if page_type == "lease"
+                                            else {}
+                                        ),
+                                    ),
+                                    html.A(
+                                        [
+                                            html.I(
+                                                className="bi bi-check2",
+                                                **{"aria-hidden": "true"},
+                                            ),
+                                            html.Span("Buy"),
+                                        ],
+                                        href="/buy",
+                                        className=(
+                                            "map-filter-toolbar__mode-button is-selected"
+                                            if page_type == "buy"
+                                            else "map-filter-toolbar__mode-button"
+                                        ),
+                                        **(
+                                            {"aria-current": "page"}
+                                            if page_type == "buy"
+                                            else {}
+                                        ),
+                                    ),
+                                ],
+                                className="map-filter-toolbar__mode",
+                                **{"aria-label": "Listing type"},
+                            ),
+                            html.Button(
+                                [
+                                    html.I(
+                                        className="bi bi-sliders2",
+                                        **{"aria-hidden": "true"},
+                                    ),
+                                    html.Span("Filters"),
+                                    html.Span(
+                                        "0",
+                                        id=f"{page_type}-filter-count-badge",
+                                        className="map-filter-toolbar__badge",
+                                        hidden=True,
+                                    ),
+                                ],
+                                id=f"{page_type}-filter-open-button",
+                                type="button",
+                                className="map-filter-toolbar__open",
+                                **{
+                                    "data-filter-open": page_type,
+                                    "data-filter-source": "toolbar",
+                                    "aria-controls": f"{page_type}-filter-panel",
+                                    "aria-expanded": "false",
+                                    "aria-haspopup": "dialog",
+                                },
+                            ),
+                        ],
+                        className="map-filter-toolbar__actions",
+                    ),
+                ],
+                className="map-filter-toolbar__top",
+            ),
+            html.Div(chips, className="map-filter-toolbar__chips"),
+        ],
+        className="map-filter-toolbar",
+        **{"data-filter-toolbar": page_type},
+    )
+
+
+def build_responsive_listing_shell(
+    *,
+    page_type: str,
+    title_card: Component,
+    user_options_card: Component,
+    map_card: Component,
+) -> html.Div:
+    """
+    Arrange one filter tree beside or over the listing map.
+
+    Desktop widths show the filter content as a sidebar. Smaller widths reuse
+    that same content inside a dismissible drawer or bottom sheet.
+    """
+    listing_label = "rentals" if page_type == "lease" else "homes"
+
+    backdrop = html.Button(
+        type="button",
+        id=f"{page_type}-filter-backdrop",
+        className="filter-panel-backdrop",
+        **{
+            "data-filter-close": page_type,
+            "data-filter-close-source": "backdrop",
+            "aria-label": "Close filters",
+            "tabIndex": "-1",
+        },
+    )
+
+    panel = html.Aside(
+        [
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.H2(
+                                "Filters",
+                                id=f"{page_type}-filter-panel-title",
+                                className="responsive-filter-panel__title",
+                                tabIndex=-1,
+                            ),
+                            html.Div(
+                                f"All {listing_label}",
+                                id=f"{page_type}-filter-panel-count",
+                                className="responsive-filter-panel__count",
+                                **{"aria-live": "polite"},
+                            ),
+                        ]
+                    ),
+                    html.Button(
+                        html.I(className="bi bi-x-lg", **{"aria-hidden": "true"}),
+                        id=f"{page_type}-filter-close-button",
+                        type="button",
+                        className="responsive-filter-panel__close",
+                        **{
+                            "data-filter-close": page_type,
+                            "data-filter-close-source": "close-button",
+                            "aria-label": "Close filters and discard unapplied changes",
+                        },
+                    ),
+                ],
+                className="responsive-filter-panel__header",
+            ),
+            html.Div(
+                [title_card, user_options_card],
+                className="responsive-filter-panel__body",
+            ),
+            html.Div(
+                [
+                    html.Button(
+                        "Clear all",
+                        id=f"{page_type}-filter-clear-button",
+                        type="button",
+                        className="responsive-filter-panel__clear",
+                        **{
+                            "data-filter-clear": page_type,
+                            "aria-label": "Clear all listing filters",
+                        },
+                    ),
+                    html.Button(
+                        f"Show {listing_label}",
+                        id=f"{page_type}-filter-apply-button",
+                        type="button",
+                        className="responsive-filter-panel__apply",
+                        **{
+                            "data-filter-apply": page_type,
+                            "aria-label": f"Apply filters and show matching {listing_label}",
+                        },
+                    ),
+                ],
+                className="responsive-filter-panel__footer",
+            ),
+        ],
+        id=f"{page_type}-filter-panel",
+        className="responsive-filter-panel options-col",
+        role="complementary",
+        **{
+            "aria-labelledby": f"{page_type}-filter-panel-title",
+            "data-filter-panel": page_type,
+        },
+    )
+
+    return html.Div(
+        [
+            backdrop,
+            panel,
+            html.Main(
+                map_card,
+                id=f"{page_type}-map-main",
+                className="listing-map-col map-col",
+            ),
+        ],
+        className="listing-page-layout",
+        **{"data-listing-page": page_type},
+    )
+
+
+def _quick_filter_button(
+    page_type: str,
+    key: str,
+    label: str,
+    section: str,
+) -> html.Button:
+    """
+    Create a shortcut that opens one section of the responsive filter panel.
+
+    ``key`` supplies the button identity while ``section`` identifies the
+    accordion section that should receive focus.
+    """
+    return html.Button(
+        label,
+        id=f"{page_type}-quick-{key}",
+        type="button",
+        className="map-filter-chip",
+        **{
+            "data-filter-open": page_type,
+            "data-filter-source": f"quick-{key}",
+            "data-filter-group": key,
+            "data-filter-section": section,
+            "aria-controls": f"{page_type}-filter-panel",
+        },
+    )
+
+
+def register_responsive_filter_callbacks(page_type: str) -> None:
+    """
+    Register the client-side callbacks for one listing page.
+
+    These callbacks capture control values, calculate preview counts, apply
+    committed filters to the map, and open the requested accordion section.
+    """
+    if page_type == "lease":
+        capture_inputs = _lease_capture_inputs()
+        capture_function = "captureLeaseFilterState"
+        preview_function = "previewLeaseFilterState"
+        applied_function = "applyLeaseFilterState"
+        quick_ids = ["location", "price", "bedrooms", "bathrooms", "pets", "more"]
+    elif page_type == "buy":
+        capture_inputs = _buy_capture_inputs()
+        capture_function = "captureBuyFilterState"
+        preview_function = "previewBuyFilterState"
+        applied_function = "applyBuyFilterState"
+        quick_ids = ["location", "price", "bedrooms", "bathrooms", "more"]
+    else:  # pragma: no cover - guarded by static page registration
+        raise ValueError(f"Unsupported listing page: {page_type}")
+
+    clientside_callback(
+        ClientsideFunction(namespace="clientside", function_name=capture_function),
+        Output(f"{page_type}-filter-draft-store", "data"),
+        Output(f"{page_type}-filter-applied-store", "data"),
+        [
+            *capture_inputs,
+            Input(f"{page_type}-filter-apply-button", "n_clicks"),
+            Input("viewport-listener", "event"),
+        ],
+        State(f"{page_type}-filter-applied-store", "data"),
+    )
+
+    clientside_callback(
+        ClientsideFunction(namespace="clientside", function_name=preview_function),
+        Output(f"{page_type}-filter-preview-store", "data"),
+        Input(f"{page_type}-filter-draft-store", "data"),
+        State(f"{page_type}-geojson-store", "data"),
+    )
+
+    clientside_callback(
+        ClientsideFunction(namespace="clientside", function_name=applied_function),
+        Output(f"{page_type}_geojson", "data"),
+        Input(f"{page_type}-filter-applied-store", "data"),
+        Input(f"{page_type}-geojson-store", "data"),
+    )
+
+    clientside_callback(
+        ClientsideFunction(namespace="clientside", function_name="openFilterAccordionSection"),
+        Output(f"{page_type}-options-accordion", "active_item"),
+        [Input(f"{page_type}-quick-{key}", "n_clicks") for key in quick_ids],
+        State(f"{page_type}-options-accordion", "active_item"),
+        prevent_initial_call=True,
+    )
+
+
+def _lease_capture_inputs() -> list[Input]:
+    """
+    Return every Dash input that contributes to the rental filter state.
+
+    The order matches the arguments accepted by ``captureLeaseFilterState``.
+    """
+    return [
+        Input("rental_price_slider", "value"),
+        Input("bedrooms_slider", "value"),
+        Input("bathrooms_slider", "value"),
+        Input("pets_radio", "value"),
+        Input("sqft_slider", "value"),
+        Input("sqft_missing_switch", "checked"),
+        Input("ppsqft_slider", "value"),
+        Input("ppsqft_missing_switch", "checked"),
+        Input("garage_spaces_slider", "value"),
+        Input("garage_missing_switch", "checked"),
+        Input("yrbuilt_slider", "value"),
+        Input("yrbuilt_missing_switch", "checked"),
+        Input("terms_checklist", "value"),
+        Input("terms_missing_switch", "checked"),
+        Input("furnished_checklist", "value"),
+        Input("furnished_missing_switch", "checked"),
+        Input("security_deposit_slider", "value"),
+        Input("security_deposit_missing_switch", "checked"),
+        Input("pet_deposit_slider", "value"),
+        Input("pet_deposit_missing_switch", "checked"),
+        Input("key_deposit_slider", "value"),
+        Input("key_deposit_missing_switch", "checked"),
+        Input("other_deposit_slider", "value"),
+        Input("other_deposit_missing_switch", "checked"),
+        Input("laundry_checklist", "value"),
+        Input("laundry_missing_switch", "checked"),
+        Input("subtype_checklist", "value"),
+        Input("listed_time_range_radio", "value"),
+        Input("listed_date_datepicker_lease", "start_date"),
+        Input("listed_date_datepicker_lease", "end_date"),
+        Input("listed_date_missing_switch", "checked"),
+        Input("isp_download_speed_slider", "value"),
+        Input("isp_upload_speed_slider", "value"),
+        Input("isp_speed_missing_switch", "checked"),
+        Input("rent_control_status", "value"),
+        Input("lease-location-input", "value"),
+        Input("lease-nearby-zip-switch", "checked"),
+        Input("lease-zip-boundary-store", "data"),
+    ]
+
+
+def _buy_capture_inputs() -> list[Input]:
+    """
+    Return every Dash input that contributes to the for-sale filter state.
+
+    The order matches the arguments accepted by ``captureBuyFilterState``.
+    """
+    return [
+        Input("list_price_slider", "value"),
+        Input("bedrooms_slider", "value"),
+        Input("bathrooms_slider", "value"),
+        Input("sqft_slider", "value"),
+        Input("sqft_missing_switch", "checked"),
+        Input("ppsqft_slider", "value"),
+        Input("ppsqft_missing_switch", "checked"),
+        Input("lot_size_slider", "value"),
+        Input("lot_size_missing_switch", "checked"),
+        Input("yrbuilt_slider", "value"),
+        Input("yrbuilt_missing_switch", "checked"),
+        Input("subtype_checklist", "value"),
+        Input("listed_time_range_radio", "value"),
+        Input("listed_date_datepicker_buy", "start_date"),
+        Input("listed_date_datepicker_buy", "end_date"),
+        Input("listed_date_missing_switch", "checked"),
+        Input("hoa_fee_slider", "value"),
+        Input("hoa_fee_missing_switch", "checked"),
+        Input("hoa_fee_frequency_checklist", "value"),
+        Input("isp_download_speed_slider", "value"),
+        Input("isp_upload_speed_slider", "value"),
+        Input("isp_speed_missing_switch", "checked"),
+        Input("buy-location-input", "value"),
+        Input("buy-nearby-zip-switch", "checked"),
+        Input("buy-zip-boundary-store", "data"),
+    ]

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,26 @@
+const { defineConfig } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 45_000,
+  expect: {
+    timeout: 7_500,
+  },
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: "line",
+  use: {
+    baseURL: "http://127.0.0.1:8050",
+    browserName: "chromium",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "uv run gunicorn --bind 127.0.0.1:8050 --workers 1 app:server",
+    url: "http://127.0.0.1:8050/health",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});

--- a/tests/e2e/responsive_filters.spec.js
+++ b/tests/e2e/responsive_filters.spec.js
@@ -1,0 +1,164 @@
+const { test, expect } = require("@playwright/test");
+
+const BASE_URL = "http://127.0.0.1:8050";
+
+/**
+ * Record unexpected browser errors raised while a test exercises the page.
+ * @param {import("@playwright/test").Page} page Playwright page under test.
+ * @returns {Promise<string[]>} Mutable error list populated by event handlers.
+ */
+async function collectPageErrors(page) {
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    const text = message.text();
+    if (
+      message.type() === "error" &&
+      !text.includes("dash-version.plotly.com") &&
+      !text.includes("Failed to load resource")
+    ) errors.push(`console: ${text}`);
+  });
+  return errors;
+}
+
+/**
+ * Wait until defaults and result counts initialize for one listing page.
+ * @param {import("@playwright/test").Page} page Playwright page under test.
+ * @param {"lease" | "buy"} pageType Listing mode expected to initialize.
+ * @returns {Promise<void>}
+ */
+async function waitForFilterState(page, pageType) {
+  await page.waitForFunction(
+    (key) => Boolean(
+      window.larentals?.responsiveFilters?.defaults?.[key] &&
+      Number.isFinite(window.larentals?.responsiveFilters?.appliedCounts?.[key])
+    ),
+    pageType,
+    { timeout: 20_000 },
+  );
+}
+
+for (const entry of [
+  { pageType: "lease", path: "/", sliderId: "rental_price_slider" },
+  { pageType: "buy", path: "/buy", sliderId: "list_price_slider" },
+]) {
+  test(`${entry.pageType} uses a map-first staged filter sheet on phones`, async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const errors = await collectPageErrors(page);
+    await page.goto(`${BASE_URL}${entry.path}`, { waitUntil: "domcontentloaded" });
+    await waitForFilterState(page, entry.pageType);
+
+    const map = page.locator("#map");
+    const toolbar = page.locator(`[data-filter-toolbar='${entry.pageType}']`);
+    const panel = page.locator(`[data-filter-panel='${entry.pageType}']`);
+    await expect(map).toBeVisible();
+    await expect(toolbar).toBeVisible();
+    await expect(panel).not.toHaveClass(/is-open/);
+    const mapBox = await map.boundingBox();
+    expect(mapBox.y).toBeLessThanOrEqual(1);
+    expect(mapBox.height).toBeGreaterThanOrEqual(800);
+
+    const initial = await page.evaluate((key) => ({
+      defaults: window.larentals.responsiveFilters.defaults[key],
+      appliedCount: window.larentals.responsiveFilters.appliedCounts[key],
+    }), entry.pageType);
+
+    await page.locator(`#${entry.pageType}-filter-open-button`).click();
+    await expect(panel).toHaveClass(/is-open/);
+    await expect(panel).toHaveAttribute("role", "dialog");
+    await expect(panel).toHaveAttribute("aria-modal", "true");
+
+    await page.evaluate(({ sliderId, upper }) => {
+      window.dash_clientside.set_props(sliderId, { value: [0, upper] });
+    }, {
+      sliderId: entry.sliderId,
+      upper: Math.max(1, Math.round(initial.defaults.priceRange[1] * 0.55)),
+    });
+
+    await page.waitForFunction(
+      (key) => window.larentals.responsiveFilters.previewCounts[key] !==
+        window.larentals.responsiveFilters.appliedCounts[key],
+      entry.pageType,
+      { timeout: 10_000 },
+    );
+    const whileEditing = await page.evaluate((key) => ({
+      appliedPrice: window.larentals.responsiveFilters.applied[key].priceRange,
+      draftPrice: window.larentals.responsiveFilters.drafts[key].priceRange,
+    }), entry.pageType);
+    expect(whileEditing.appliedPrice).toEqual(initial.defaults.priceRange);
+    expect(whileEditing.draftPrice).not.toEqual(initial.defaults.priceRange);
+
+    const sheetGeometry = await page.evaluate((key) => {
+      const panel = document.getElementById(`${key}-filter-panel`).getBoundingClientRect();
+      const footer = document.querySelector(`#${key}-filter-panel .responsive-filter-panel__footer`).getBoundingClientRect();
+      return { panel: { top: panel.top, bottom: panel.bottom }, footer: { top: footer.top, bottom: footer.bottom } };
+    }, entry.pageType);
+    expect(sheetGeometry.footer.top).toBeGreaterThanOrEqual(sheetGeometry.panel.top);
+    expect(sheetGeometry.footer.bottom).toBeLessThanOrEqual(sheetGeometry.panel.bottom + 1);
+    await page.evaluate((key) => document.getElementById(`${key}-filter-apply-button`).click(), entry.pageType);
+    await expect(panel).not.toHaveClass(/is-open/);
+    await page.waitForFunction(
+      (key) => window.larentals.responsiveFilters.applied[key].priceRange[1] !==
+        window.larentals.responsiveFilters.defaults[key].priceRange[1],
+      entry.pageType,
+    );
+    await expect(page.locator(`#${entry.pageType}-quick-price`)).toHaveClass(/map-filter-chip--active/);
+
+    await page.locator(`#${entry.pageType}-filter-open-button`).click();
+    await page.evaluate(() => {
+      window.dash_clientside.set_props("bedrooms_slider", { value: [2, 3] });
+    });
+    await page.locator(`#${entry.pageType}-filter-close-button`).click({ force: true });
+    await page.waitForFunction(
+      (key) => JSON.stringify(window.larentals.responsiveFilters.drafts[key].bedroomsRange) ===
+        JSON.stringify(window.larentals.responsiveFilters.applied[key].bedroomsRange),
+      entry.pageType,
+    );
+
+    await page.locator(`#${entry.pageType}-quick-price`).click();
+    await page.waitForFunction(
+      (key) => JSON.stringify(window.larentals.responsiveFilters.applied[key].priceRange) ===
+        JSON.stringify(window.larentals.responsiveFilters.defaults[key].priceRange),
+      entry.pageType,
+    );
+    await expect(page.locator(`#${entry.pageType}-quick-price`)).not.toHaveClass(/map-filter-chip--active/);
+
+    if (entry.pageType === "lease") {
+      await page.evaluate(() => {
+        window.dash_clientside.set_props("lease-layers-control", { overlays: ["Schools"] });
+      });
+      await expect(page.locator("#lease-school-layer-map-prompt")).toHaveClass(/school-layer-map-prompt--visible/);
+      await page.evaluate(() => document.getElementById("lease-school-layer-show-filters-button").click());
+      await expect(panel).toHaveClass(/is-open/);
+      await expect(page.locator("#lease-school-layer-controls-card")).toHaveClass(/school-layer-panel-card--active/);
+      await page.keyboard.press("Escape");
+      await expect(page.locator("#lease-school-layer-show-filters-button")).toBeFocused();
+    }
+
+    expect(errors).toEqual([]);
+  });
+}
+
+test("tablet uses a right drawer and desktop keeps a persistent sidebar", async ({ page }) => {
+  const errors = await collectPageErrors(page);
+  await page.setViewportSize({ width: 900, height: 1000 });
+  await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
+  await waitForFilterState(page, "lease");
+  await expect(page.locator("[data-filter-toolbar='lease']")).toBeVisible();
+  await page.locator("#lease-filter-open-button").click();
+  const tabletPanel = await page.locator("[data-filter-panel='lease']").boundingBox();
+  expect(tabletPanel.width).toBeGreaterThanOrEqual(430);
+  expect(tabletPanel.x).toBeGreaterThanOrEqual(455);
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#lease-filter-open-button")).toBeFocused();
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.waitForTimeout(250);
+  await expect(page.locator("[data-filter-toolbar='lease']")).toBeHidden();
+  const desktopPanel = await page.locator("[data-filter-panel='lease']").boundingBox();
+  expect(desktopPanel.width).toBeGreaterThanOrEqual(320);
+  expect(desktopPanel.width).toBeLessThanOrEqual(400);
+  await expect(page.locator("[data-filter-panel='lease']")).toHaveAttribute("role", "complementary");
+
+  expect(errors).toEqual([]);
+});

--- a/tests/test_component_smoke.py
+++ b/tests/test_component_smoke.py
@@ -2,7 +2,11 @@ import unittest
 
 from dash import dcc, html
 
-from pages.component_factories import build_subtype_filter, build_title_card
+from pages.component_factories import (
+    build_location_filter_components,
+    build_subtype_filter,
+    build_title_card,
+)
 from pages.components import BuyComponents, LeaseComponents
 
 
@@ -19,6 +23,17 @@ def _collect_components(component):
 
 
 class ComponentsSmokeTest(unittest.TestCase):
+    def test_location_inputs_use_associated_labels(self) -> None:
+        for page_type in ("lease", "buy"):
+            with self.subTest(page_type=page_type):
+                component = build_location_filter_components(page_type)
+                label, location_input = component.children[:2]
+
+                self.assertIsInstance(label, html.Label)
+                self.assertEqual(label.htmlFor, f"{page_type}-location-input")
+                self.assertIsInstance(location_input, dcc.Input)
+                self.assertNotIn("aria-label", location_input.to_plotly_json()["props"])
+
     def test_buy_components_build_core_cards(self) -> None:
         components = BuyComponents()
 

--- a/tests/test_responsive_filter_ui.py
+++ b/tests/test_responsive_filter_ui.py
@@ -1,0 +1,139 @@
+import unittest
+from collections.abc import Iterator
+from typing import Any
+
+from dash import html
+
+from pages.buy_components import BuyComponents
+from pages.lease_components import LeaseComponents
+from pages.responsive_filter_ui import (
+    FILTER_UI_BREAKPOINT,
+    build_filter_ui_stores,
+    build_map_filter_toolbar,
+    build_responsive_listing_shell,
+)
+
+
+def _collect_components(component: Any) -> Iterator[Any]:
+    """
+    Yield every component and text node in a Dash component tree.
+
+    Lists and tuples are traversed recursively so tests can inspect deeply
+    nested controls without depending on their exact layout structure.
+    """
+    if isinstance(component, (list, tuple)):
+        for child in component:
+            yield from _collect_components(child)
+        return
+
+    yield component
+    children = getattr(component, "children", None)
+    if children is not None:
+        yield from _collect_components(children)
+
+
+class ResponsiveFilterUiTest(unittest.TestCase):
+    def test_filter_shell_keeps_one_filter_tree_and_map_main(self) -> None:
+        """
+        Verify the responsive shell does not duplicate the filter controls.
+        """
+        shell = build_responsive_listing_shell(
+            page_type="lease",
+            title_card=html.Div("Title", id="test-title"),
+            user_options_card=html.Div("Filters", id="test-filter-tree"),
+            map_card=html.Div("Map", id="test-map"),
+        )
+
+        components = list(_collect_components(shell))
+        component_ids = [getattr(component, "id", None) for component in components]
+
+        self.assertEqual(component_ids.count("test-filter-tree"), 1)
+        self.assertIn("lease-filter-panel", component_ids)
+        self.assertIn("lease-filter-backdrop", component_ids)
+        self.assertIn("lease-map-main", component_ids)
+
+        panel = next(
+            component
+            for component in components
+            if getattr(component, "id", None) == "lease-filter-panel"
+        )
+        self.assertEqual(panel.role, "complementary")
+        self.assertEqual(
+            panel.to_plotly_json()["props"]["data-filter-panel"],
+            "lease",
+        )
+
+    def test_toolbar_has_accessible_open_trigger_and_quick_filters(self) -> None:
+        """
+        Verify the compact toolbar exposes its controls and current mode.
+        """
+        toolbar = build_map_filter_toolbar("buy")
+        components = list(_collect_components(toolbar))
+        component_ids = {getattr(component, "id", None) for component in components}
+
+        self.assertIn("buy-filter-open-button", component_ids)
+        self.assertIn("buy-quick-location", component_ids)
+        self.assertIn("buy-quick-price", component_ids)
+        self.assertIn("buy-quick-bedrooms", component_ids)
+        self.assertIn("buy-quick-bathrooms", component_ids)
+        self.assertIn("buy-quick-more", component_ids)
+
+        open_button = next(
+            component
+            for component in components
+            if getattr(component, "id", None) == "buy-filter-open-button"
+        )
+        props = open_button.to_plotly_json()["props"]
+        self.assertEqual(props["aria-controls"], "buy-filter-panel")
+        self.assertEqual(props["aria-haspopup"], "dialog")
+        self.assertEqual(props["aria-expanded"], "false")
+
+        mode_nav = next(
+            component
+            for component in components
+            if getattr(component, "className", None) == "map-filter-toolbar__mode"
+        )
+        self.assertEqual(mode_nav.to_plotly_json()["props"]["aria-label"], "Listing type")
+
+        current_modes = [
+            component
+            for component in components
+            if hasattr(component, "to_plotly_json")
+            and component.to_plotly_json()["props"].get("aria-current") == "page"
+        ]
+        self.assertEqual(len(current_modes), 1)
+        self.assertEqual(current_modes[0].href, "/buy")
+        self.assertIn("is-selected", current_modes[0].className)
+
+    def test_page_filter_stores_are_scoped(self) -> None:
+        """
+        Verify each listing page receives its own filter state stores.
+        """
+        stores = build_filter_ui_stores("lease")
+        self.assertEqual(
+            [store.id for store in stores],
+            [
+                "lease-filter-draft-store",
+                "lease-filter-applied-store",
+                "lease-filter-preview-store",
+            ],
+        )
+        self.assertEqual(stores[-1].data, {"count": None})
+
+    def test_essential_sections_only_are_expanded_initially(self) -> None:
+        """
+        Verify the initial sidebar emphasizes the most-used filter sections.
+        """
+        self.assertEqual(
+            LeaseComponents.CONFIG.active_filter_items,
+            ("location", "monthly_rent", "bedrooms"),
+        )
+        self.assertEqual(
+            BuyComponents.CONFIG.active_filter_items,
+            ("location", "list_price", "bedrooms"),
+        )
+        self.assertEqual(FILTER_UI_BREAKPOINT, 1100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add responsive filter layouts for desktop, tablet, and mobile.
- Use a persistent desktop sidebar, tablet drawer, and mobile bottom sheet.
- Stage mobile/tablet filter changes until users apply them.
- Add live result previews, active-filter chips, clear/remove actions, and accessible focus handling.
- Clarify the active Rent/Buy mode with segmented-control styling.
- Shorten the location placeholder and add a native accessible label.
- Add Python type hints, multiline docstrings, JavaScript JSDoc, and responsive tests.

## Testing

- Python tests pass.
- Responsive Playwright tests pass across phone, tablet, and desktop.
- JavaScript syntax and diff checks pass.